### PR TITLE
Use cropped isostasy output for the ice domain

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -120,4 +120,5 @@ clean:
 	rm -f  *.x gmon.out $(objdir)/*.o $(objdir)/*.mod $(objdir)/*.a $(objdir)/*.so
 	rm -rf *.x.dSYM
 	rm -f ${YELMOROOT}/libyelmo/include/*.a ${YELMOROOT}/libyelmo/include/*.o 
+	rm -f ${ISOSTASYROOT}/libisostasy/include/*.a ${ISOSTASYROOT}/libisostasy/include/*.o 
 

--- a/config/foehn_gfortran
+++ b/config/foehn_gfortran
@@ -1,0 +1,26 @@
+FC = gfortran
+
+INC_NC = -I/usr/include # -Wdate-time -D_FORTIFY_SOURCE=2
+LIB_NC = -L/usr/lib/x86_64-linux-gnu -lnetcdff -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -lnetcdf -lnetcdf -ldl -lm 
+
+LISROOT = /usr/include/lis
+INC_LIS = -I${LISROOT}/include
+LIB_LIS = -L${LISROOT}/lib/ -llis
+
+YELMOROOT = yelmo
+INC_YELMO = -I${YELMOROOT}/libyelmo/include
+LIB_YELMO = -L${YELMOROOT}/libyelmo/include -lyelmo
+
+FFTWROOT = /usr/lib/x86_64-linux-gnu
+INC_FFTW = -I$(FFTWROOT)/include
+LIB_FFTW = -L$(FFTWROOT)/lib -lfftw3 -lm
+
+ISOSTASYROOT = FastIsostasy
+INC_ISOSTASY = -I${ISOSTASYROOT}/libisostasy/include 
+LIB_ISOSTASY = -L${ISOSTASYROOT}/libisostasy/include -lisostasy
+
+FFLAGS = -I$(objdir) -J$(objdir) -m64 -ffree-line-length-none 
+LFLAGS  = $(LIB_YELMO) $(LIB_NC) $(LIB_LIS) $(LIB_ISOSTASY) $(LIB_FFTW) -Wl,-zmuldefs
+DFLAGS_NODEBUG = -O2
+DFLAGS_DEBUG   = -w -g -p -ggdb -ffpe-trap=invalid,zero,overflow -fbacktrace -fcheck=all -Wp,-DDEBUG
+DFLAGS_PROFILE = -O2 -p -ggdb

--- a/par/yelmo_Antarctica.nml
+++ b/par/yelmo_Antarctica.nml
@@ -147,7 +147,7 @@
 /
 
 &ydyn
-    solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", l1l2", "l1l2-noslip"
+    solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", "l1l2", "l1l2-noslip"
     visc_method         = 1               ! 0: constant visc=visc_const, 1: dynamic viscosity
     visc_const          = 1e7             ! [Pa a] Constant value for viscosity (if visc_method=0)
     beta_method         = 3               ! 0: constant beta; 1: linear (beta=cb/u0); 2: psuedo-plastic-power; 3: Regularized Coulomb

--- a/yelmox.f90
+++ b/yelmox.f90
@@ -445,9 +445,10 @@ program yelmox
     call isos_init_state(isos1, yelmo1%bnd%z_bed, yelmo1%tpo%now%H_ice, &
         yelmo1%bnd%z_sl, 0.0_wp, time, set_ref=.FALSE.)
     
-    yelmo1%bnd%z_bed = isos1%now%z_bed
-    yelmo1%bnd%z_sl  = isos1%now%z_ss
-
+    yelmo1%bnd%z_bed = isos1%now%z_bed(isos1%domain%icrop1:isos1%domain%icrop2, &
+        isos1%domain%jcrop1:isos1%domain%jcrop2)
+    yelmo1%bnd%z_sl  = isos1%now%z_ss(isos1%domain%icrop1:isos1%domain%icrop2, &
+        isos1%domain%jcrop1:isos1%domain%jcrop2)
 
     call sealevel_update(sealev,year_bp=time_bp)
     yelmo1%bnd%z_sl  = sealev%z_sl 
@@ -517,8 +518,11 @@ program yelmox
     if (yelmo1%par%use_restart) then 
         ! Perform additional startup steps when using a restart
 
-        ! Set boundary module variables equal to restarted value         
-        isos1%now%z_bed  = yelmo1%bnd%z_bed
+        ! Set boundary module variables equal to restarted value
+        ! TODO: this should be adapted so that we have a good mapping between square
+        ! and rectangular domain
+        isos1%now%z_bed(isos1%domain%icrop1:isos1%domain%icrop2, &
+            isos1%domain%jcrop1:isos1%domain%jcrop2)  = yelmo1%bnd%z_bed
 
     else
         ! No restart file used
@@ -779,8 +783,10 @@ program yelmox
         ! == ISOSTASY and SEA LEVEL (REGIONAL) ===========================================
         call isos_update(isos1, yelmo1%tpo%now%H_ice, sealev%z_sl, time, &
                                                     dwdt_corr=yelmo1%bnd%dzbdt_corr)
-        yelmo1%bnd%z_bed = isos1%now%z_bed
-        yelmo1%bnd%z_sl  = isos1%now%z_ss
+        yelmo1%bnd%z_bed = isos1%now%z_bed(isos1%domain%icrop1:isos1%domain%icrop2, &
+            isos1%domain%jcrop1:isos1%domain%jcrop2)
+        yelmo1%bnd%z_sl  = isos1%now%z_ss(isos1%domain%icrop1:isos1%domain%icrop2, &
+            isos1%domain%jcrop1:isos1%domain%jcrop2)
 
         call timer_step(tmrs,comp=1,time_mod=[time-ctl%dtt,time]*1e-3,label="isostasy") 
         

--- a/yelmox.f90
+++ b/yelmox.f90
@@ -400,6 +400,7 @@ program yelmox
     ! Initialize global sea level model (bnd%z_sl)
     call sealevel_init(sealev,path_par)
 
+    write(*,*) "(nx, ny) = ", yelmo1%grd%nx, yelmo1%grd%ny
     ! Initialize bedrock model 
     call isos_init(isos1,path_par,"isos",yelmo1%grd%nx,yelmo1%grd%ny,yelmo1%grd%dx,yelmo1%grd%dy)
 
@@ -445,10 +446,8 @@ program yelmox
     call isos_init_state(isos1, yelmo1%bnd%z_bed, yelmo1%tpo%now%H_ice, &
         yelmo1%bnd%z_sl, 0.0_wp, time, set_ref=.FALSE.)
     
-    yelmo1%bnd%z_bed = isos1%now%z_bed(isos1%domain%icrop1:isos1%domain%icrop2, &
-        isos1%domain%jcrop1:isos1%domain%jcrop2)
-    yelmo1%bnd%z_sl  = isos1%now%z_ss(isos1%domain%icrop1:isos1%domain%icrop2, &
-        isos1%domain%jcrop1:isos1%domain%jcrop2)
+    yelmo1%bnd%z_bed = isos1%output%z_bed
+    yelmo1%bnd%z_sl  = isos1%output%z_ss
 
     call sealevel_update(sealev,year_bp=time_bp)
     yelmo1%bnd%z_sl  = sealev%z_sl 
@@ -519,8 +518,6 @@ program yelmox
         ! Perform additional startup steps when using a restart
 
         ! Set boundary module variables equal to restarted value
-        ! TODO: this should be adapted so that we have a good mapping between square
-        ! and rectangular domain
         isos1%now%z_bed(isos1%domain%icrop1:isos1%domain%icrop2, &
             isos1%domain%jcrop1:isos1%domain%jcrop2)  = yelmo1%bnd%z_bed
 
@@ -783,10 +780,8 @@ program yelmox
         ! == ISOSTASY and SEA LEVEL (REGIONAL) ===========================================
         call isos_update(isos1, yelmo1%tpo%now%H_ice, sealev%z_sl, time, &
                                                     dwdt_corr=yelmo1%bnd%dzbdt_corr)
-        yelmo1%bnd%z_bed = isos1%now%z_bed(isos1%domain%icrop1:isos1%domain%icrop2, &
-            isos1%domain%jcrop1:isos1%domain%jcrop2)
-        yelmo1%bnd%z_sl  = isos1%now%z_ss(isos1%domain%icrop1:isos1%domain%icrop2, &
-            isos1%domain%jcrop1:isos1%domain%jcrop2)
+        yelmo1%bnd%z_bed = isos1%output%z_bed
+        yelmo1%bnd%z_sl  = isos1%output%z_ss
 
         call timer_step(tmrs,comp=1,time_mod=[time-ctl%dtt,time]*1e-3,label="isostasy") 
         


### PR DESCRIPTION
The domain of FastIsostasy is a square extension when Yelmo uses a rectangular domain. This difference between both modules makes it important to use `isos%output%var` when passing `var` from FastIsostasy to Yelmo. This is now included.

Minors:
- I think `make clean` should also clean FastIsostasy.
- A config for foehn has been added.
- A typo was corrected in `par/yelmo_Antarctica.nml`