### PR TITLE
isos nml: add correct_compression, lumping and everyhting in km

### DIFF
--- a/par/yelmo_Antarctica.nml
+++ b/par/yelmo_Antarctica.nml
@@ -569,6 +569,7 @@
     viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
     tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
     rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
                                 ! and mantle viscosity
@@ -589,7 +590,7 @@
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-16KM_GIA_HR24.nc"
     litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
     log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
     stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file

--- a/par/yelmo_Antarctica.nml
+++ b/par/yelmo_Antarctica.nml
@@ -541,32 +541,36 @@
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
     include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
-    dt_prognostics  = 0.1           ! [yr] Max. timestep to recalculate prognostics
-    dt_diagnostics  = 10.0          ! [yr] Min. timestep to recalculate diagnostics
-    pad             = 1024.0        ! [km] Padding around the domain (preferably chosen as a power
+    dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
+    dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
+    pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
+
+    ! Rheology methods
     mantle = "rheology_file"        ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
     lithosphere = "rheology_file"   ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    lithospheric_smoothing = 0.0
-    viscosity_scaling_method = "stddev"  ! "scale" or "min" or "max"
-    viscosity_scaling = 0.0              ! Only used if viscosity_scaling_method = "scale"
-    rheo_smoothing_radius = 40.0         ! [km] Smoothing radius for rheology
-    layering    = "parallel"             ! "parallel", "equalized" or "folded"
-    nl          = 5                      ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 25.0                   ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 100.0, 150.0, 200.0, 250.0, 300.0         ! [km] Depth of layer boundaries.
-                                         ! Only used if layering="equalized". First value
-                                         ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 1.e21, 1.e21, 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
-                                         ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
-                                         ! viscosity field is provided.
-    tau         = 2000.0                 ! [yr] Relaxation time. Only used if method=1 or 2.
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "parallel"        ! "parallel" or "equalized"
+    lumping     = "min"             ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
+    
+    ! Rheology parameters
+    nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
+                                    ! Only used if layering="equalized". First value 
+                                    ! overwritten if visc_method="rheology_file".
+    viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
+                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                    ! viscosity field is provided.
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
+    rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
+                                ! and mantle viscosity
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -578,22 +582,23 @@
     rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
                                     ! displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km] Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-32KM_GIA_HR24.nc"
+    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
     litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
     log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
     stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
-/
 
+/
 &barysealevel
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "none"    ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant

--- a/par/yelmo_Antarctica.nml
+++ b/par/yelmo_Antarctica.nml
@@ -562,6 +562,7 @@
     
     ! Rheology parameters
     nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
     zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".

--- a/par/yelmo_Antarctica_rtip.nml
+++ b/par/yelmo_Antarctica_rtip.nml
@@ -558,7 +558,6 @@
     pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-
     ! Rheology methods
     mantle = "rheology_file"        ! Choose mantle viscosity field, options:
                                     ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
@@ -578,6 +577,7 @@
     viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
     tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
     rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
                                 ! and mantle viscosity
@@ -598,7 +598,7 @@
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-16KM_GIA_HR24.nc"
     litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
     log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
     stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file

--- a/par/yelmo_Antarctica_rtip.nml
+++ b/par/yelmo_Antarctica_rtip.nml
@@ -571,6 +571,7 @@
     
     ! Rheology parameters
     nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
     zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".

--- a/par/yelmo_Antarctica_rtip.nml
+++ b/par/yelmo_Antarctica_rtip.nml
@@ -544,11 +544,13 @@
  obs_name        = 'ghf'      
  ghf_const       = 50.0       
 /
+
 &isos
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
     include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
@@ -556,28 +558,28 @@
     pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
+
+    ! Rheology methods
     mantle = "rheology_file"        ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
     lithosphere = "rheology_file"   ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    rheo_smoothing_radius = 0.0     ! [km] Gaussian moothing radius for lithospheric thickness
-                                    ! and mantle viscosity
-    viscosity_scaling_method = "scale"     ! "scale", "std", "min" or "max"
-    viscosity_scaling = 1.          ! "scale"   => visc = viscosity_scaling * visc
-                                    ! "std"     => visc = visc + viscosity_scaling * stddev(visc)
-                                    ! "min"     => visc = min(visc) * viscosity_scaling
-                                    ! "max"     => visc = max(visc) * viscosity_scaling
-    layering    = "parallel"        ! "parallel", "equalized" or "folded"
-    nl          = 5                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "parallel"        ! "parallel" or "equalized"
+    lumping     = "min"             ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
+    
+    ! Rheology parameters
+    nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
     zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".
     viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
+    rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
+                                ! and mantle viscosity
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -589,7 +591,7 @@
     rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
                                     ! displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km] Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
@@ -605,6 +607,7 @@
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "none"    ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant

--- a/par/yelmo_Greenland.nml
+++ b/par/yelmo_Greenland.nml
@@ -535,7 +535,7 @@
     ghf_const = 50.0           ! [mW/m^2]
 
 /
-&isostasy
+&isos
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
@@ -590,10 +590,11 @@
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
     restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_Greenland.nml
+++ b/par/yelmo_Greenland.nml
@@ -535,35 +535,38 @@
     ghf_const = 50.0           ! [mW/m^2]
 
 /
-
-&isos
+&isostasy
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 512.              ! [km] Padding around domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"              ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
-    lithosphere = "uniform"         ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+    ! Rheology methods
+    mantle = "uniform"          ! Choose mantle viscosity field, options:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "uniform"     ! Choose lithospheric thickness field:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "equalized"   ! "parallel" or "equalized"
+    lumping     = "min"         ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
     viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"       ! "parallel", "equalized" or "folded"
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
-                                    ! Only used if layering="equalized". First value 
-                                    ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
-                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
-                                    ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    
+    ! Rheology parameters
+    nl          = 1             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl = 88.                    ! [km] Depth of layer boundaries. The first value is overwritten
+                                ! if a lithospheric thickness filed is provided.
+    viscosities = 1.e21         ! [Pa s] Layer viscosities. Only used if
+                                ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -572,10 +575,9 @@
     rho_seawater    = 1028.0        ! [kg/m^3]
     rho_water       = 1000.0        ! [kg/m^3]
     rho_uppermantle = 3400.0        ! [kg/m^3]
-    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
-                                    ! displacement from the viscous one
+    rho_litho       = 3200.0        ! [kg/m^3]  If 0: decouple the elastic displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km]  Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
@@ -585,13 +587,13 @@
 /
 
 &barysealevel
-    method      = "file"    ! "const": BSL = bsl_init throughout sim
+    method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
     bsl_init    = 0.0       ! [m] BSL relative to present day
-    sl_path     = "input/paleo300ka_hybrid_aicc2012.nc"    ! Input time series filename
-    sl_name     = "rsl"    ! Variable name in netcdf file, if relevant
+    sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
+    sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "none"
-    restart    = "None"
+    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_Greenland_rembo.nml
+++ b/par/yelmo_Greenland_rembo.nml
@@ -540,35 +540,38 @@
 
 /
 
-
-&isos
+&isostasy
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 512.              ! [km] Padding around domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"              ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
-    lithosphere = "uniform"         ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+    ! Rheology methods
+    mantle = "uniform"          ! Choose mantle viscosity field, options:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "uniform"     ! Choose lithospheric thickness field:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "equalized"   ! "parallel" or "equalized"
+    lumping     = "min"         ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
     viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"       ! "parallel", "equalized" or "folded"
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
-                                    ! Only used if layering="equalized". First value 
-                                    ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
-                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
-                                    ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    
+    ! Rheology parameters
+    nl          = 1             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl = 88.                    ! [km] Depth of layer boundaries. The first value is overwritten
+                                ! if a lithospheric thickness filed is provided.
+    viscosities = 1.e21         ! [Pa s] Layer viscosities. Only used if
+                                ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -577,10 +580,9 @@
     rho_seawater    = 1028.0        ! [kg/m^3]
     rho_water       = 1000.0        ! [kg/m^3]
     rho_uppermantle = 3400.0        ! [kg/m^3]
-    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
-                                    ! displacement from the viscous one
+    rho_litho       = 3200.0        ! [kg/m^3]  If 0: decouple the elastic displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km]  Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
@@ -594,9 +596,9 @@
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
     bsl_init    = 0.0       ! [m] BSL relative to present day
-    sl_path     = "none"    ! Input time series filename
+    sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc"
-    restart    = "None"
+    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_Greenland_rembo.nml
+++ b/par/yelmo_Greenland_rembo.nml
@@ -540,7 +540,7 @@
 
 /
 
-&isostasy
+&isos
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
@@ -595,10 +595,11 @@
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
     restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_LIS.nml
+++ b/par/yelmo_LIS.nml
@@ -499,35 +499,38 @@
     ghf_const = 50.0           ! [mW/m^2]
 
 /
-
-&isos
+&isostasy
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 512.              ! [km] Padding around domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"              ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
-    lithosphere = "uniform"         ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+    ! Rheology methods
+    mantle = "uniform"          ! Choose mantle viscosity field, options:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "uniform"     ! Choose lithospheric thickness field:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "equalized"   ! "parallel" or "equalized"
+    lumping     = "min"         ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
     viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"       ! "parallel", "equalized" or "folded"
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
-                                    ! Only used if layering="equalized". First value 
-                                    ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
-                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
-                                    ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    
+    ! Rheology parameters
+    nl          = 1             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl = 88.                    ! [km] Depth of layer boundaries. The first value is overwritten
+                                ! if a lithospheric thickness filed is provided.
+    viscosities = 1.e21         ! [Pa s] Layer viscosities. Only used if
+                                ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -536,10 +539,9 @@
     rho_seawater    = 1028.0        ! [kg/m^3]
     rho_water       = 1000.0        ! [kg/m^3]
     rho_uppermantle = 3400.0        ! [kg/m^3]
-    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
-                                    ! displacement from the viscous one
+    rho_litho       = 3200.0        ! [kg/m^3]  If 0: decouple the elastic displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km]  Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
@@ -549,13 +551,13 @@
 /
 
 &barysealevel
-    method      = "const"   ! "const": BSL = bsl_init throughout sim
+    method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
-    bsl_init    = -120.0    ! [m] BSL relative to present day
-    sl_path     = "none"    ! Input time series filename
+    bsl_init    = 0.0       ! [m] BSL relative to present day
+    sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "none"
-    restart    = "None"
+    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_LIS.nml
+++ b/par/yelmo_LIS.nml
@@ -499,7 +499,7 @@
     ghf_const = 50.0           ! [mW/m^2]
 
 /
-&isostasy
+&isos
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
@@ -554,10 +554,11 @@
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
     restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_North.nml
+++ b/par/yelmo_North.nml
@@ -499,35 +499,38 @@
     ghf_const = 50.0           ! [mW/m^2]
 
 /
-
-&isos
+&isostasy
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 512.              ! [km] Padding around domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"              ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
-    lithosphere = "uniform"         ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+    ! Rheology methods
+    mantle = "uniform"          ! Choose mantle viscosity field, options:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "uniform"     ! Choose lithospheric thickness field:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "equalized"   ! "parallel" or "equalized"
+    lumping     = "min"         ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
     viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"       ! "parallel", "equalized" or "folded"
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
-                                    ! Only used if layering="equalized". First value 
-                                    ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
-                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
-                                    ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    
+    ! Rheology parameters
+    nl          = 1             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl = 88.                    ! [km] Depth of layer boundaries. The first value is overwritten
+                                ! if a lithospheric thickness filed is provided.
+    viscosities = 1.e21         ! [Pa s] Layer viscosities. Only used if
+                                ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -536,10 +539,9 @@
     rho_seawater    = 1028.0        ! [kg/m^3]
     rho_water       = 1000.0        ! [kg/m^3]
     rho_uppermantle = 3400.0        ! [kg/m^3]
-    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
-                                    ! displacement from the viscous one
+    rho_litho       = 3200.0        ! [kg/m^3]  If 0: decouple the elastic displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km]  Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
@@ -549,13 +551,13 @@
 /
 
 &barysealevel
-    method      = "const"   ! "const": BSL = bsl_init throughout sim
+    method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
-    bsl_init    = -120.0    ! [m] BSL relative to present day
-    sl_path     = "none"    ! Input time series filename
+    bsl_init    = 0.0       ! [m] BSL relative to present day
+    sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "none"
-    restart    = "None"
+    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_North.nml
+++ b/par/yelmo_North.nml
@@ -499,7 +499,7 @@
     ghf_const = 50.0           ! [mW/m^2]
 
 /
-&isostasy
+&isos
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
@@ -554,10 +554,11 @@
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
     restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_Pyrenees.nml
+++ b/par/yelmo_Pyrenees.nml
@@ -451,34 +451,38 @@
 
 /
 
-&isos
+&isostasy
     ! Options
-    heterogeneous_ssh    = .true.  ! Sea level varies spatially?
-    interactive_sealevel = .true.  ! Sea level interacts with solid Earth deformation?
-    correct_distortion   = .false. ! Account for distortion of projection?
-    method          = 3            ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
-    dt_prognostics  = 1.           ! [yr] Max. timestep to recalculate prognostics
-    dt_diagnostics  = 10.          ! [yr] Min. timestep to recalculate diagnostics
-    pad             = 128.         ! [km] Padding around the domain (preferably chosen as a power
-                                   ! of 2 multiplied by the resolution)
+    heterogeneous_ssh = .true.      ! Sea level varies spatially?
+    interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
+    correct_distortion = .false.    ! Account for distortion of projection?
+    method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
+    dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
+    dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
+    pad         = 512.              ! [km] Padding around domain (preferably chosen as a power
+                                    ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"                  ! Choose mantle viscosity field, options:
-                                        ! "uniform", "rheology_file"
-    lithosphere = "uniform"             ! Choose lithospheric thickness field:
-                                        ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
-    viscosity_scaling        = 1.       ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"           ! "parallel", "equalized" or "folded"
-    nl          = 2                     ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.                   ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.             ! [km] Depth of layer boundaries.
-                                        ! Only used if layering="equalized". First value 
-                                        ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e24, 2.e24          ! [Pa s] Layer viscosities. Only used if
-                                        ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
-                                        ! viscosity field is provided.
-    tau         = 3e3                   ! [yr] Relaxation time. Only used if method=1 or 2.
+    ! Rheology methods
+    mantle = "uniform"          ! Choose mantle viscosity field, options:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "uniform"     ! Choose lithospheric thickness field:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "equalized"   ! "parallel" or "equalized"
+    lumping     = "min"         ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
+    
+    ! Rheology parameters
+    nl          = 1             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl = 88.                    ! [km] Depth of layer boundaries. The first value is overwritten
+                                ! if a lithospheric thickness filed is provided.
+    viscosities = 1.e21         ! [Pa s] Layer viscosities. Only used if
+                                ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -487,26 +491,25 @@
     rho_seawater    = 1028.0        ! [kg/m^3]
     rho_water       = 1000.0        ! [kg/m^3]
     rho_uppermantle = 3400.0        ! [kg/m^3]
-    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
-                                    ! displacement from the viscous one
+    rho_litho       = 3200.0        ! [kg/m^3]  If 0: decouple the elastic displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km]  Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
-    restart         = "None"
-    mask_file       = "None"
-    rheology_file   = "None"
+    restart = "None"
+    mask_file = "None"
+    rheology_file = "None"
 /
 
 &barysealevel
-    method       = "const"   ! "const": BSL = bsl_init throughout sim
-                             ! "file": BSL = time series provided from sl_path
-                             ! "fastiso": BSL = sum of contributions from fastiso domains
-    bsl_init     = -120.0    ! [m] BSL relative to present day
-    sl_path      = "none"    ! Input time series filename
-    sl_name      = "none"    ! Variable name in netcdf file, if relevant
-    A_ocean_pd   = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "none"
-    restart      = "none"
+    method      = "fastiso" ! "const": BSL = bsl_init throughout sim
+                            ! "file": BSL = time series provided from sl_path
+                            ! "fastiso": BSL = sum of contributions from fastiso domains
+    bsl_init    = 0.0       ! [m] BSL relative to present day
+    sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
+    sl_name     = "none"    ! Variable name in netcdf file, if relevant
+    A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
+    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_Pyrenees.nml
+++ b/par/yelmo_Pyrenees.nml
@@ -451,7 +451,7 @@
 
 /
 
-&isostasy
+&isos
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
@@ -506,10 +506,11 @@
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
     restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_bipolar.nml
+++ b/par/yelmo_bipolar.nml
@@ -295,9 +295,10 @@
 /
 
 &barysealevel
-    method      = 'fastiso' ! 'const': BSL = bsl_init throughout sim
-                            ! 'file': BSL = time series provided from sl_path
-                            ! 'fastiso': BSL = sum of contributions from fastiso domains
+    method      = "fastiso" ! "const": BSL = bsl_init throughout sim
+                            ! "file": BSL = time series provided from sl_path
+                            ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = 'none'    ! Input time series filename
     sl_name     = 'none'    ! Variable name in netcdf file, if relevant
@@ -993,6 +994,7 @@
     viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
     tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
     rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
                                 ! and mantle viscosity
@@ -1013,7 +1015,7 @@
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-16KM_GIA_HR24.nc"
     litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
     log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
     stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file

--- a/par/yelmo_bipolar.nml
+++ b/par/yelmo_bipolar.nml
@@ -913,30 +913,34 @@
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 512.              ! [km] Padding around domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = 'uniform'              ! Choose mantle viscosity field, options:
-                                    ! 'uniform', 'rheology_file'
-    lithosphere = 'uniform'         ! Choose lithospheric thickness field:
-                                    ! 'uniform', 'rheology_file'
-    viscosity_scaling_method = 'scale'  ! 'scale' or 'min' or 'max'
-    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = 'scale'
-    layering    = 'equalized'       ! 'parallel', 'equalized' or 'folded'
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering='parallel'.
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
-                                    ! Only used if layering='equalized'. First value 
-                                    ! overwritten if visc_method='rheology_file'.
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
-                                    ! mantle = 'uniform' or 'gaussian_plus' or 'gaussian_minus'.
-                                    ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    ! Rheology methods
+    mantle = "uniform"          ! Choose mantle viscosity field, options:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "uniform"     ! Choose lithospheric thickness field:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "equalized"   ! "parallel" or "equalized"
+    lumping     = "min"         ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
+    
+    ! Rheology parameters
+    nl          = 1             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl = 88.                    ! [km] Depth of layer boundaries. The first value is overwritten
+                                ! if a lithospheric thickness filed is provided.
+    viscosities = 1.e21         ! [Pa s] Layer viscosities. Only used if
+                                ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -945,46 +949,52 @@
     rho_seawater    = 1028.0        ! [kg/m^3]
     rho_water       = 1000.0        ! [kg/m^3]
     rho_uppermantle = 3400.0        ! [kg/m^3]
-    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
-                                    ! displacement from the viscous one
+    rho_litho       = 3200.0        ! [kg/m^3]  If 0: decouple the elastic displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km]  Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
-    restart = 'None'
-    mask_file = 'None'
-    rheology_file = 'None'
+    restart = "None"
+    mask_file = "None"
+    rheology_file = "None"
 /
 
 &isos_south
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
-    dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
+    dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = 'uniform'              ! Choose mantle viscosity field, options:
-                                    ! 'uniform', 'rheology_file'
-    lithosphere = 'uniform'         ! Choose lithospheric thickness field:
-                                    ! 'uniform', 'rheology_file'
-    viscosity_scaling_method = 'scale'  ! 'scale' or 'min' or 'max'
-    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = 'scale'
-    layering    = 'equalized'       ! 'parallel', 'equalized' or 'folded'
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering='parallel'.
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
-                                    ! Only used if layering='equalized'. First value 
-                                    ! overwritten if visc_method='rheology_file'.
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
-                                    ! mantle = 'uniform' or 'gaussian_plus' or 'gaussian_minus'.
+
+    ! Rheology methods
+    mantle = "rheology_file"        ! Choose mantle viscosity field, options:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "rheology_file"   ! Choose lithospheric thickness field:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "parallel"        ! "parallel" or "equalized"
+    lumping     = "min"             ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
+    
+    ! Rheology parameters
+    nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
+                                    ! Only used if layering="equalized". First value 
+                                    ! overwritten if visc_method="rheology_file".
+    viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
+                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
+    rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
+                                ! and mantle viscosity
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -996,13 +1006,17 @@
     rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
                                     ! displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km] Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
-    restart = 'None'
-    mask_file = 'None'
-    rheology_file = 'None'
+    restart = "None"
+    mask_file = "None"
+    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
+    log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
+    stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
+
 /
 
 &negis

--- a/par/yelmo_bipolar.nml
+++ b/par/yelmo_bipolar.nml
@@ -986,6 +986,7 @@
     
     ! Rheology parameters
     nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
     zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".

--- a/par/yelmo_ismip6_Antarctica.nml
+++ b/par/yelmo_ismip6_Antarctica.nml
@@ -602,6 +602,7 @@
     viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
     tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
     rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
                                 ! and mantle viscosity
@@ -622,12 +623,13 @@
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-16KM_GIA_HR24.nc"
     litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
     log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
     stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
 
 /
+
 &barysealevel
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path

--- a/par/yelmo_ismip6_Antarctica.nml
+++ b/par/yelmo_ismip6_Antarctica.nml
@@ -595,6 +595,7 @@
     
     ! Rheology parameters
     nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
     zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".

--- a/par/yelmo_ismip6_Antarctica.nml
+++ b/par/yelmo_ismip6_Antarctica.nml
@@ -573,30 +573,37 @@
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
-    dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
+    dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"              ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
-    lithosphere = "uniform"         ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+
+    ! Rheology methods
+    mantle = "rheology_file"        ! Choose mantle viscosity field, options:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "rheology_file"   ! Choose lithospheric thickness field:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "parallel"        ! "parallel" or "equalized"
+    lumping     = "min"             ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
     viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"       ! "parallel", "equalized" or "folded"
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
+    
+    ! Rheology parameters
+    nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
+    viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
+    rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
+                                ! and mantle viscosity
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -608,19 +615,23 @@
     rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
                                     ! displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km] Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "None"
-/
+    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
+    log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
+    stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
 
+/
 &barysealevel
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "none"    ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant

--- a/par/yelmo_nahosmip_Antarctica.nml
+++ b/par/yelmo_nahosmip_Antarctica.nml
@@ -602,6 +602,7 @@
     viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
     tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
     rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
                                 ! and mantle viscosity
@@ -622,12 +623,12 @@
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-16KM_GIA_HR24.nc"
     litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
     log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
     stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
-
 /
+
 &barysealevel
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path

--- a/par/yelmo_nahosmip_Antarctica.nml
+++ b/par/yelmo_nahosmip_Antarctica.nml
@@ -595,6 +595,7 @@
     
     ! Rheology parameters
     nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
     zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".
@@ -627,7 +628,6 @@
     stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
 
 /
-
 &barysealevel
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path

--- a/par/yelmo_nahosmip_Antarctica.nml
+++ b/par/yelmo_nahosmip_Antarctica.nml
@@ -573,30 +573,37 @@
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
-    dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
+    dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"              ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
-    lithosphere = "uniform"         ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+
+    ! Rheology methods
+    mantle = "rheology_file"        ! Choose mantle viscosity field, options:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "rheology_file"   ! Choose lithospheric thickness field:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "parallel"        ! "parallel" or "equalized"
+    lumping     = "min"             ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
     viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"       ! "parallel", "equalized" or "folded"
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
+    
+    ! Rheology parameters
+    nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
+    viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
+    rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
+                                ! and mantle viscosity
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -608,19 +615,24 @@
     rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
                                     ! displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km] Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "None"
+    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
+    log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
+    stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
+
 /
 
 &barysealevel
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "none"    ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant

--- a/par/yelmo_pd_Antarctica.nml
+++ b/par/yelmo_pd_Antarctica.nml
@@ -579,6 +579,7 @@
     
     ! Rheology parameters
     nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
     zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".

--- a/par/yelmo_pd_Antarctica.nml
+++ b/par/yelmo_pd_Antarctica.nml
@@ -586,6 +586,7 @@
     viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
     tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
     rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
                                 ! and mantle viscosity
@@ -606,7 +607,7 @@
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-16KM_GIA_HR24.nc"
     litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
     log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
     stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file

--- a/par/yelmo_pd_Antarctica.nml
+++ b/par/yelmo_pd_Antarctica.nml
@@ -557,30 +557,37 @@
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
-    dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
+    dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"              ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
-    lithosphere = "uniform"         ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+
+    ! Rheology methods
+    mantle = "rheology_file"        ! Choose mantle viscosity field, options:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "rheology_file"   ! Choose lithospheric thickness field:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "parallel"        ! "parallel" or "equalized"
+    lumping     = "min"             ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
     viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"       ! "parallel", "equalized" or "folded"
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
+    
+    ! Rheology parameters
+    nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
                                     ! Only used if layering="equalized". First value 
                                     ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
+    viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
                                     ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
                                     ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
+    rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
+                                ! and mantle viscosity
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -592,19 +599,23 @@
     rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
                                     ! displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km] Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
     restart = "None"
     mask_file = "None"
-    rheology_file = "None"
-/
+    rheology_file = "isostasy_data/earth_structure/ANT-16KM_GIA_HR24.nc"
+    litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
+    log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
+    stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
 
+/
 &barysealevel
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "none"    ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant

--- a/par/yelmo_pd_Greenland.nml
+++ b/par/yelmo_pd_Greenland.nml
@@ -585,35 +585,38 @@
     ghf_const = 50.0           ! [mW/m^2]
 
 /
-
-&isos
+&isostasy
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
     correct_distortion = .false.    ! Account for distortion of projection?
     method          = 3             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
     dt_prognostics  = 1.            ! [yr] Max. timestep to recalculate prognostics
     dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
-    pad         = 512.              ! [km] Padding around the domain (preferably chosen as a power
+    pad         = 512.              ! [km] Padding around domain (preferably chosen as a power
                                     ! of 2 multiplied by the resolution)
 
-    ! Rheology
-    mantle = "uniform"              ! Choose mantle viscosity field, options:
-                                    ! "uniform", "rheology_file"
-    lithosphere = "uniform"         ! Choose lithospheric thickness field:
-                                    ! "uniform", "rheology_file"
-    viscosity_scaling_method = "scale"  ! "scale" or "min" or "max"
+    ! Rheology methods
+    mantle = "uniform"          ! Choose mantle viscosity field, options:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "uniform"     ! Choose lithospheric thickness field:
+                                ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "equalized"   ! "parallel" or "equalized"
+    lumping     = "min"         ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
     viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
-    layering    = "equalized"       ! "parallel", "equalized" or "folded"
-    nl          = 2                 ! [1] Number of viscous layers for sub-lithospheric mantle
-    dl          = 10.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
-    zl          = 88., 600.         ! [km] Depth of layer boundaries.
-                                    ! Only used if layering="equalized". First value 
-                                    ! overwritten if visc_method="rheology_file".
-    viscosities = 1.e21, 2.e21      ! [Pa s] Layer viscosities. Only used if
-                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
-                                    ! viscosity field is provided.
-    tau         = 2000.0            ! [yr] Relaxation time. Only used if method=1 or 2.
+    
+    ! Rheology parameters
+    nl          = 1             ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl = 88.                    ! [km] Depth of layer boundaries. The first value is overwritten
+                                ! if a lithospheric thickness filed is provided.
+    viscosities = 1.e21         ! [Pa s] Layer viscosities. Only used if
+                                ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
 
     ! Physical constants
     E               = 66.0          ! [GPa] Young modulus
@@ -622,10 +625,9 @@
     rho_seawater    = 1028.0        ! [kg/m^3]
     rho_water       = 1000.0        ! [kg/m^3]
     rho_uppermantle = 3400.0        ! [kg/m^3]
-    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
-                                    ! displacement from the viscous one
+    rho_litho       = 3200.0        ! [kg/m^3]  If 0: decouple the elastic displacement from the viscous one
     g               = 9.81          ! [m/s^2]
-    r_earth         = 6.378e6       ! [m]  Earth radius, Coulon et al. (2021)
+    r_earth         = 6.378e3       ! [km]  Earth radius, Coulon et al. (2021)
     m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
 
     ! Files
@@ -639,9 +641,9 @@
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
     bsl_init    = 0.0       ! [m] BSL relative to present day
-    sl_path     = "none"    ! Input time series filename
+    sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc"
-    restart    = "None"
+    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    restart     = "None"    ! Path to restart file
 /

--- a/par/yelmo_pd_Greenland.nml
+++ b/par/yelmo_pd_Greenland.nml
@@ -585,7 +585,7 @@
     ghf_const = 50.0           ! [mW/m^2]
 
 /
-&isostasy
+&isos
     ! Options
     heterogeneous_ssh = .true.      ! Sea level varies spatially?
     interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
@@ -640,10 +640,11 @@
     method      = "fastiso" ! "const": BSL = bsl_init throughout sim
                             ! "file": BSL = time series provided from sl_path
                             ! "fastiso": BSL = sum of contributions from fastiso domains
+                            ! "mixed": combine "file" and "fastiso"
     bsl_init    = 0.0       ! [m] BSL relative to present day
     sl_path     = "input/sl_deglaciation.dat"   ! Input time series filename
     sl_name     = "none"    ! Variable name in netcdf file, if relevant
     A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
-    A_ocean_path = "../isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
+    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc" ! Path to ocean surface file
     restart     = "None"    ! Path to restart file
 /


### PR DESCRIPTION
Update the namelists in accordance with FastIsostasy v1.0-rc1. Include `correct_compression`, `lumping` as parameters and put all distances in km