### PR TITLE
Add ydyn.ssa_solver="energy" and set ydyn.ssa_lat_bc="all" in all par files

### DIFF
--- a/input/esm/esm_nudge.nml
+++ b/input/esm/esm_nudge.nml
@@ -1,0 +1,716 @@
+&var1
+    filename    = "var_test.nc"
+    name        = "var1"
+    units_in    = "K"
+    units_out   = "K"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = TRUE 
+    time_par    = 1950, 1960, 1
+/
+
+! ====== ESM experiment definitions ======
+
+&ctrl
+    experiment      = "ctrl"
+/
+
+&1pctCO2
+    experiment      = "1pctCO2"
+/
+
+&ssp126
+    experiment      = "ssp126"
+/
+
+&ssp585
+    experiment      = "ssp585"
+/
+
+! =========== ATMOSPHERE ===========
+
+! ======== Reference period ========
+&gcm_ts_ref
+    filename    = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_ERA5-3H_RACMO2.3p2_1990-2019_monthly_DETRENDED.nc"
+    name        = "t2m_dt"
+    units_in    = "K"
+    units_out   = "K"
+    unit_scale  = 1.0
+    unit_offset = 0.0
+    with_time   = True
+    time_par    = 1990.0, 2019.0, 1.0, 12.0
+/
+
+&gcm_pr_ref
+    filename    = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_ERA5-3H_RACMO2.3p2_1990-2019_monthly_DETRENDED.nc"
+    name        = "precip_dt"
+    units_in    = "kg m-2 month-1"
+    units_out   = "mm yr-1"
+    unit_scale  = 0.08333
+    unit_offset = 0.0
+    with_time   = True
+    time_par    = 1990.0, 2019.0, 1.0, 12.0
+/
+
+&gcm_zs_ref
+    filename    = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_ERA5-3H_RACMO2.3p2_1979-2022_monthly.nc"
+    name        = "z_srf"
+    units_in    = "m"
+    units_out   = "m"
+    unit_scale  = 1.0         
+    unit_offset = 0.0 
+    with_time   = False 
+    time_par    = 2000, 2000, 0, 1
+/
+
+! ======== Variability =============
+
+&gcm_ts_var
+    filename    = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_ERA5-3H_RACMO2.3p2_1979-2022_monthly.nc"
+    name        = "t2m"
+    units_in    = "K"
+    units_out   = "K"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = True 
+    time_par    = 1979.0, 2022.0, 1.0, 12.0
+/
+
+&gcm_pr_var
+    filename    = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_ERA5-3H_RACMO2.3p2_1979-2022_monthly.nc"
+    name        = "precip"
+    units_in    = "kg m-2 month-1"
+    units_out   = "mm yr-1"
+    unit_scale  = 0.08333         
+    unit_offset = 0.0 
+    with_time   = True
+    time_par    = 1979.0, 2022.0, 1.0, 12.0
+/
+
+&gcm_zs_var
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/{grid_name}_AWI_ESM_PIcontrol_surfelev.nc
+    name        = "OROMEA"
+    units_in    = "m"
+    units_out   = "m"
+    unit_scale  = 1.0         
+    unit_offset = 0.0 
+    with_time   = False 
+    time_par    = 2000, 2000, 0, 1
+/
+
+! ======== ESM Reference period ========
+&gcm_ts_esm_ref
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_nudgedhigh03_temp2_4501to5000.nc"
+    !filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_orig_PI_temp2_4501to5000.nc"
+    name        = "temp2"
+    units_in    = "K"
+    units_out   = "K"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = True 
+    time_par    = 4501, 5000, 1, 12
+/
+
+&gcm_pr_esm_ref
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_nudgedhigh03_aprl_aprc_4501to5000.nc"
+    !filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_orig_PI_aprl_aprc_4501to5000.nc"
+    name        = "aprc"
+    units_in    = "kg m-2 s-1"
+    units_out   = "mm yr-1"
+    unit_scale  = 31556926.25        ! CMIP standard sec_to_year  
+    unit_offset = 0.0 
+    with_time   = True 
+    time_par    = 4501, 5000, 1, 12
+/
+
+! ======= Historical period =======
+&gcm_ts_hist
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_orig_PI_temp2_4501to5000.nc"
+    name        = "temp2"
+    units_in    = "K"
+    units_out   = "K"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = True 
+    time_par    = 4501, 5000, 1, 12
+/
+
+&gcm_pr_hist
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_orig_PI_aprl_aprc_4501to5000.nc"
+    name        = "aprc"
+    units_in    = "kg m-2 s-1"
+    units_out   = "mm yr-1"
+    unit_scale  = 31556926.25        ! CMIP standard sec_to_year  
+    unit_offset = 0.0 
+    with_time   = True 
+    time_par    = 4501, 5000, 1, 12
+/
+
+! ======== Projection period ========
+&gcm_ts_proj
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_nudgedhigh03_temp2_4501to5000.nc"
+    !filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_orig_PI_temp2_4501to5000.nc"
+    name        = "temp2"
+    units_in    = "K"
+    units_out   = "K"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = True 
+    time_par    = 4501, 5000, 1, 12
+/
+
+&gcm_pr_proj
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_nudgedhigh03_aprl_aprc_4501to5000.nc"
+    !filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/ATM/{grid_name}_orig_PI_aprl_aprc_4501to5000.nc"
+    name        = "aprc"
+    units_in    = "kg m-2 s-1"
+    units_out   = "mm yr-1"
+    unit_scale  = 31556926.25        ! CMIP standard sec_to_year  
+    unit_offset = 0.0 
+    with_time   = True 
+    time_par    = 4501, 5000, 1, 12
+/
+
+! ========      OCEAN      =========
+
+! ======== Reference period ========
+&gcm_to_ref
+    filename    = "ice_data/{domain}/{grid_name}/ERA-INT-ORAS5/{grid_name}_ORAS5_1990-2019_DETRENDED.nc"
+    name        = "thetao_dt"
+    units_in    = "degrees C"
+    units_out   = "K"
+    unit_scale  = 1.0
+    unit_offset = 273.15
+    with_time   = True
+    time_par    = 1990, 2019, 1, 1
+/
+
+&gcm_so_ref
+    filename    = "ice_data/{domain}/{grid_name}/ERA-INT-ORAS5/{grid_name}_ORAS5_1990-2019_DETRENDED.nc"
+    name        = "so_dt"
+    units_in    = "PSU"
+    units_out   = "PSU"
+    unit_scale  = 1.0
+    unit_offset = 0.0
+    with_time   = True
+    time_par    = 1990, 2019, 1, 1
+/
+
+! ======== Variability period ========
+&gcm_to_var
+    filename    = "ice_data/{domain}/{grid_name}/ERA-INT-ORAS5/{grid_name}_ORAS5_1979-2024_thetao.nc"
+    name        = "thetao"
+    units_in    = "degrees C"
+    units_out   = "K"
+    unit_scale  = 1.0 
+    unit_offset = 273.15 
+    with_time   = True
+    time_par    = 1979, 2024, 1, 1
+/
+
+&gcm_so_var
+    filename    = "ice_data/{domain}/{grid_name}/ERA-INT-ORAS5/{grid_name}_ORAS5_1979-2024_so.nc"
+    name        = "so"
+    units_in    = "PSU"
+    units_out   = "PSU"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = True
+    time_par    = 1979, 2024, 1, 1
+/
+
+! ======== ESM Reference period ========
+&gcm_to_esm_ref
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/OCN/{grid_name}_orig_reg_oceantemp_4501to5000.nc"
+    name        = "temp"
+    units_in    = "degrees C"
+    units_out   = "K"
+    unit_scale  = 1.0
+    unit_offset = 273.15 
+    with_time   = True
+    time_par    = 4501, 5000, 1, 1
+/
+
+&gcm_so_esm_ref
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/OCN/{grid_name}_orig_reg_oceansalt_4501to5000.nc"
+    name        = "salt"
+    units_in    = "PSU"
+    units_out   = "PSU"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = True
+    time_par    = 4501, 5000, 1, 1
+/
+
+! ======== Historical period ========
+&gcm_to_hist
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/OCN/{grid_name}_orig_reg_oceantemp_4501to5000.nc"
+    name        = "temp"
+    units_in    = "degrees C"
+    units_out   = "K"
+    unit_scale  = 1.0
+    unit_offset = 273.15 
+    with_time   = True
+    time_par    = 4501, 5000, 1, 1
+/
+
+&gcm_so_hist
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/OCN/{grid_name}_orig_reg_oceansalt_4501to5000.nc"
+    name        = "salt"
+    units_in    = "PSU"
+    units_out   = "PSU"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = True
+    time_par    = 4501, 5000, 1, 1
+/
+
+! ======== Projection period ========
+&gcm_to_proj
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/OCN/{grid_name}_orig_reg_oceantemp_4501to5000.nc"
+    name        = "temp"
+    units_in    = "degrees C"
+    units_out   = "K"
+    unit_scale  = 1.0
+    unit_offset = 273.15 
+    with_time   = True
+    time_par    = 4501, 5000, 1, 1
+/
+
+&gcm_so_proj
+    filename    = "ice_data/{domain}/{grid_name}/Nudge_Skiba26/OCN/{grid_name}_orig_reg_oceansalt_4501to5000.nc"
+    name        = "salt"
+    units_in    = "PSU"
+    units_out   = "PSU"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = True
+    time_par    = 4501, 5000, 1, 1
+/
+
+! === Other fields ===
+
+&basins
+    filename    = "ice_data/{domain}/{grid_name}/{grid_name}_BASINS-nasa.nc"
+    name        = "basin_reese"
+    units_in    = "1"
+    units_out   = "1"
+    unit_scale  = 1.0 
+    unit_offset = 0.0 
+    with_time   = False
+    time_par    = 2020, 2020, 0, 1
+/
+
+! =====================================================
+!
+! CMIP output variable list
+!
+! =====================================================
+
+&cmip_out_lithk
+    name            = "lithk"
+    long_name       = "Ice sheet thickness"
+    var_type        = "ST"
+    standard_name   = "land_ice_thickness"
+    units_in        = "m"
+    units_out       = "m"
+    unit_scale      = 1.0 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_orog
+    name            = "orog"
+    long_name       = "Ice sheet surface elevation"
+    var_type        = "ST"
+    standard_name   = "surface_altitude"
+    units_in        = "m"
+    units_out       = "m"
+    unit_scale      = 1.0 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_base
+    name            = "base"
+    long_name       = "Ice sheet base elevation"
+    var_type        = "ST"
+    standard_name   = "base_altitude"
+    units_in        = "m"
+    units_out       = "m"
+    unit_scale      = 1.0 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_topg
+    name            = "topg"
+    long_name       = "Bedrock elevation"
+    var_type        = "ST"
+    standard_name   = "bedrock_altitude"
+    units_in        = "m"
+    units_out       = "m"
+    unit_scale      = 1.0 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_hfgeoubed
+    name            = "hfgeoubed"
+    long_name       = "Geothermal heat flux"
+    var_type        = "CST"
+    standard_name   = "upward_geothermal_heat_flux_at_ground_level"
+    units_in        = "mW m^−2"
+    units_out       = "W m^-2"
+    unit_scale      = 1e-3 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_acabf
+    name            = "acabf"
+    long_name       = "Surface mass balance flux"
+    var_type        = "FL"
+    standard_name   = "land_ice_surface_specific_mass_balance_flux"
+    units_in        = "m i.e. yr^-1"
+    units_out       = "kg m^-2 s^-1"
+    unit_scale      = 2.90586e-05     ! 1/31556926.0*(917/1000)*1000
+    unit_offset     = 0.0 
+/
+
+&cmip_out_libmassbfgr
+    name            = "libmassbfgr"
+    long_name       = "Basal mass balance flux beneath grounded ice"
+    var_type        = "FL"
+    standard_name   = "land_ice_basal_specific_mass_balance_flux"
+    units_in        = "m i.e. yr^-1"
+    units_out       = "kg m^-2 s^-1"
+    unit_scale      = 2.90586e-05     ! 1/31556926.0*(917/1000)*1000
+    unit_offset     = 0.0 
+/
+
+&cmip_out_libmassbffl
+    name            = "libmassbffl"
+    long_name       = "Basal mass balance flux beneath floating ice"
+    var_type        = "FL"
+    standard_name   = "land_ice_basal_specific_mass_balance_flux"
+    units_in        = "m i.e. yr^-1"
+    units_out       = "kg m^-2 s^-1"
+    unit_scale      = 2.90586e-05     ! 1/31556926.0*(917/1000)*1000
+    unit_offset     = 0.0 
+/
+
+&cmip_out_dlithkdt
+    name            = "dlithkdt"
+    long_name       = "Ice thickness imbalance"
+    var_type        = "FL"
+    standard_name   = "tendency_of_land_ice_thickness"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_xvelsurf
+    name            = "xvelsurf"
+    long_name       = "Surface velocity in x direction"
+    var_type        = "ST"
+    standard_name   = "land_ice_surface_x_velocity"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_yvelsurf
+    name            = "yvelsurf"
+    long_name       = "Surface velocity in y direction"
+    var_type        = "ST"
+    standard_name   = "land_ice_surface_y_velocity"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_zvelsurf
+    name            = "zvelsurf"
+    long_name       = "Surface velocity in z direction"
+    var_type        = "ST"
+    standard_name   = "land_ice_surface_upward_velocity"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+
+&cmip_out_xvelbase
+    name            = "xvelbase"
+    long_name       = "Basal velocity in x direction"
+    var_type        = "ST"
+    standard_name   = "land_ice_basal_x_velocity"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_yvelbase
+    name            = "yvelbase"
+    long_name       = "Basal velocity in y direction"
+    var_type        = "ST"
+    standard_name   = "land_ice_basal_y_velocity"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_zvelbase
+    name            = "zvelbase"
+    long_name       = "Basal velocity in z direction"
+    var_type        = "ST"
+    standard_name   = "land_ice_basal_upward_velocity"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_xvelmean
+    name            = "xvelmean"
+    long_name       = "Mean velocity in x direction"
+    var_type        = "ST"
+    standard_name   = "land_ice_vertical_mean_x_velocity"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_yvelmean
+    name            = "yvelmean"
+    long_name       = "Mean velocity in y direction"
+    var_type        = "ST"
+    standard_name   = "land_ice_vertical_mean_y_velocity"
+    units_in        = "m yr^-1"
+    units_out       = "m s^-1"
+    unit_scale      =  3.168876e-08    ! == 1/31556926.0(ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_litemptop
+    name            = "litemptop"
+    long_name       = "Ice surface temperature"
+    var_type        = "ST"
+    standard_name   = "temperature_at_top_of_ice_sheet_model"
+    units_in        = "K"
+    units_out       = "K"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_litempbotgr
+    name            = "litempbotgr"
+    long_name       = "Basal temperature beneath grounded ice sheet"
+    var_type        = "ST"
+    standard_name   = "temperature_at_base_of_ice_sheet_model"
+    units_in        = "K"
+    units_out       = "K"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_litempbotfl
+    name            = "litempbotfl"
+    long_name       = "Basal temperature beneath floating ice sheet"
+    var_type        = "ST"
+    standard_name   = "temperature_at_base_of_ice_sheet_model"
+    units_in        = "K"
+    units_out       = "K"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_strbasemag
+    name            = "strbasemag"
+    long_name       = "Magnitude of basal drag"
+    var_type        = "ST"
+    standard_name   = "land_ice_basal_drag"
+    units_in        = "Pa"
+    units_out       = "Pa"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_licalvf
+    name            = "licalvf"
+    long_name       = "Land ice calving flux"
+    var_type        = "FL"
+    standard_name   = "land_ice_specific_mass_flux_due_to_calving"
+    units_in        = "m i.e. yr^-1"
+    units_out       = "kg m^-2 s^-1"
+    unit_scale      = 2.90586e-05     ! 1/31556926.0*(917/1000)*1000
+    unit_offset     = 0.0 
+/
+
+&cmip_out_lifmassbf
+    name            = "lifmassbf"
+    long_name       = "Ice front melt and calving flux"
+    var_type        = "FL"
+    standard_name   = "land_ice_specific_mass_flux_due_to_calving_and_ice_front_melting"
+    units_in        = "m i.e. yr^-1"
+    units_out       = "kg m^-2 s^-1"
+    unit_scale      = 2.90586e-05     ! 1/31556926.0*(917/1000)*1000
+    unit_offset     = 0.0 
+/
+&cmip_out_ligroundf
+    name            = "ligroundf"
+    long_name       = "Grounding line flux"
+    var_type        = "FL"
+    standard_name   = "land_ice_specific_mass_flux_at_grounding_line"
+    units_in        = "m i.e. yr^-1"
+    units_out       = "kg m^-2 s^-1"
+    unit_scale      = 2.90586e-05     ! 1/31556926.0*(917/1000)*1000
+    unit_offset     = 0.0 
+/
+
+&cmip_out_sftgif
+    name            = "sftgif"
+    long_name       = "Land ice area fraction"
+    var_type        = "ST"
+    standard_name   = "land_ice_area_fraction"
+    units_in        = "1"
+    units_out       = "1"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_sftgrf
+    name            = "sftgrf"
+    long_name       = "Grounded ice sheet area fraction"
+    var_type        = "ST"
+    standard_name   = "grounded_ice_sheet_area_fraction"
+    units_in        = "1"
+    units_out       = "1"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_sftflf
+    name            = "sftflf"
+    long_name       = "Floating ice sheet area fraction"
+    var_type        = "ST"
+    standard_name   = "floating_ice_shelf_area_fraction"
+    units_in        = "1"
+    units_out       = "1"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_lim
+    name            = "lim"
+    long_name       = "Total ice sheet mass"
+    var_type        = "ST"
+    standard_name   = "land_ice_mass"
+    units_in        = "kg"
+    units_out       = "kg"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_limnsw
+    name            = "limnsw"
+    long_name       = "Total ice sheet mass above flotation"
+    var_type        = "ST"
+    standard_name   = "land_ice_mass_not_displacing_sea_water"
+    units_in        = "kg"
+    units_out       = "kg"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_iareagr
+    name            = "iareagr"
+    long_name       = "Grounded ice area"
+    var_type        = "ST"
+    standard_name   = "grounded_ice_sheet_area"
+    units_in        = "m^2"
+    units_out       = "m^2"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_iareafl
+    name            = "iareafl"
+    long_name       = "Floating ice area"
+    var_type        = "ST"
+    standard_name   = "floating_ice_shelf_area"
+    units_in        = "m^2"
+    units_out       = "m^2"
+    unit_scale      = 1.0
+    unit_offset     = 0.0 
+/
+
+&cmip_out_tendacabf
+    name            = "tendacabf"
+    long_name       = "Total SMB flux"
+    var_type        = "FL"
+    standard_name   = "tendency_of_land_ice_mass_due_to_surface_mass_balance"
+    units_in        = "kg yr^-1"
+    units_out       = "kg s^-1"
+    unit_scale      = 3.168876e-08    ! == 1/31556926.0 (ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_tendlibmassbf
+    name            = "tendlibmassbf"
+    long_name       = "Total BMB flux"
+    var_type        = "FL"
+    standard_name   = "tendency_of_land_ice_mass_due_to_basal_mass_balance"
+    units_in        = "kg yr^-1"
+    units_out       = "kg s^-1"
+    unit_scale      = 3.168876e-08    ! == 1/31556926.0 (ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_tendlibmassbffl
+    name            = "tendlibmassbffl"
+    long_name       = "Total BMB flux beneath floating ice"
+    var_type        = "FL"
+    standard_name   = "tendency_of_land_ice_mass_due_to_basal_mass_balance"
+    units_in        = "kg yr^-1"
+    units_out       = "kg s^-1"
+    unit_scale      = 3.168876e-08    ! == 1/31556926.0 (ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_tendlicalvf
+    name            = "tendlicalvf"
+    long_name       = "Total calving flux"
+    var_type        = "FL"
+    standard_name   = "tendency_of_land_ice_mass_due_to_calving"
+    units_in        = "kg yr^-1"
+    units_out       = "kg s^-1"
+    unit_scale      = 3.168876e-08    ! == 1/31556926.0 (ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_tendlifmassbf
+    name            = "tendlifmassbf"
+    long_name       = "Total calving and ice front melting flux"
+    var_type        = "FL"
+    standard_name   = "tendency_of_land_ice_mass_due_to_calving_and_ice_front_melting"
+    units_in        = "kg yr^-1"
+    units_out       = "kg s^-1"
+    unit_scale      = 3.168876e-08    ! == 1/31556926.0 (ISMIP standard) 
+    unit_offset     = 0.0 
+/
+
+&cmip_out_tendligroundf
+    name            = "tendligroundf"
+    long_name       = "Total grounding line flux"
+    var_type        = "FL"
+    standard_name   = "tendency_of_grounded_ice_mass"
+    units_in        = "kg yr^-1"
+    units_out       = "kg s^-1"
+    unit_scale      = 3.168876e-08    ! == 1/31556926.0 (ISMIP standard) 
+    unit_offset     = 0.0 
+/
+

--- a/libs/esm.f90
+++ b/libs/esm.f90
@@ -185,7 +185,7 @@ contains
         
     end subroutine esm_experiment_def
 
-    subroutine esm_forcing_init(esm,filename,domain,grid_name,gcm,scenario,experiment)
+    subroutine esm_forcing_init(esm,filename,domain,grid_name,gcm,scenario,experiment,use_esm,use_hist,use_proj)
 
         implicit none 
     
@@ -196,6 +196,7 @@ contains
         character(len=*), intent(IN), optional :: gcm
         character(len=*), intent(IN), optional :: scenario
         character(len=*), intent(IN), optional :: experiment
+        logical,          intent(IN), optional :: use_esm, use_hist, use_proj
     
         ! Local variables 
         character(len=256) :: gcm_now
@@ -338,75 +339,67 @@ contains
  
         ! Initialize all variables from namelist entries 
         ! General fields (needed? switch to reese basins?)
-        call varslice_init_nml_esm(esm%basins,  filename,  "basins", domain,grid_name,esm%gcm,esm%scenario)
+        call varslice_init_nml_esm(esm%basins, filename, "basins", domain, grid_name, esm%gcm, esm%scenario)
             
+        ! Climatology
         ! Reference period
-        call varslice_init_nml_esm(esm%ts_ref,  filename,trim(grp_ts_ref), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%pr_ref,  filename,trim(grp_pr_ref), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%zs_ref,  filename,trim(grp_zs_ref), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%to_ref,  filename,trim(grp_to_ref), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%so_ref,  filename,trim(grp_so_ref), domain,grid_name,esm%gcm,esm%scenario)
-        
+        call varslice_init_nml_esm(esm%ts_ref, filename, trim(grp_ts_ref), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%pr_ref, filename, trim(grp_pr_ref), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%zs_ref, filename, trim(grp_zs_ref), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%to_ref, filename, trim(grp_to_ref), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%so_ref, filename, trim(grp_so_ref), domain, grid_name, esm%gcm, esm%scenario)
+
         ! Initialize variables at other grids if source grid is different
-        call varslice_init_nml_esm(esm%to_ref_src, filename,trim(grp_to_ref), domain,grid_name,esm%gcm,esm%scenario)
+        call varslice_init_nml_esm(esm%to_ref_src, filename, trim(grp_to_ref), domain, grid_name, esm%gcm, esm%scenario)
 
-        ! Variability reference period
+        ! Variability
+        ! Transient dependent field
+        call varslice_init_nml_esm(esm%ts_var, filename, trim(grp_ts_var), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%pr_var, filename, trim(grp_pr_var), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%to_var, filename, trim(grp_to_var), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%so_var, filename, trim(grp_so_var), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%zs_var, filename, trim(grp_zs_var), domain, grid_name, esm%gcm, esm%scenario)
         ! Reference period
-        call varslice_init_nml_esm(esm%ts_var,  filename,trim(grp_ts_var), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%pr_var,  filename,trim(grp_pr_var), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%to_var,  filename,trim(grp_to_var), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%so_var,  filename,trim(grp_so_var), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%zs_var,  filename,trim(grp_zs_var), domain,grid_name,esm%gcm,esm%scenario)
-        ! Reference period
-        call varslice_init_nml_esm(esm%ts_var_ref,  filename,trim(grp_ts_var), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%pr_var_ref,  filename,trim(grp_pr_var), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%to_var_ref,  filename,trim(grp_to_var), domain,grid_name,esm%gcm,esm%scenario)
-        call varslice_init_nml_esm(esm%so_var_ref,  filename,trim(grp_so_var), domain,grid_name,esm%gcm,esm%scenario)
-
-        ! Load reference time independent fields
-        call varslice_update(esm%zs_ref)
+        call varslice_init_nml_esm(esm%ts_var_ref, filename, trim(grp_ts_var), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%pr_var_ref, filename, trim(grp_pr_var), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%to_var_ref, filename, trim(grp_to_var), domain, grid_name, esm%gcm, esm%scenario)
+        call varslice_init_nml_esm(esm%so_var_ref, filename, trim(grp_so_var), domain, grid_name, esm%gcm, esm%scenario)
 
         ! Transient dependent fields
         if (trim(esm%ctrl_run_type) .eq. "transient") then
             ! ESM reference period
             !if (esm%use_esm) then
-            if (.FALSE.) then
-                call varslice_init_nml_esm(esm%ts_esm_ref,  filename,trim(grp_ts_esm_ref), domain,grid_name,esm%gcm,esm%scenario)
-                call varslice_init_nml_esm(esm%pr_esm_ref,  filename,trim(grp_pr_esm_ref), domain,grid_name,esm%gcm,esm%scenario)
-                call varslice_init_nml_esm(esm%to_esm_ref,  filename,trim(grp_to_esm_ref), domain,grid_name,esm%gcm,esm%scenario)
-                call varslice_init_nml_esm(esm%so_esm_ref,  filename,trim(grp_so_esm_ref), domain,grid_name,esm%gcm,esm%scenario)
-                ! 1D files: Only need to load once.
-                call varslice_update(esm%ts_esm_ref)
-                call varslice_update(esm%pr_esm_ref)
-                call varslice_update(esm%to_esm_ref)
-                call varslice_update(esm%so_esm_ref)
-                !call varslice_update(esm%zs_esm_ref)
+            if (use_esm .and. .TRUE.) then
+                call varslice_init_nml_esm(esm%ts_esm_ref, filename, trim(grp_ts_esm_ref), domain, grid_name, esm%gcm, esm%scenario)
+                call varslice_init_nml_esm(esm%pr_esm_ref, filename, trim(grp_pr_esm_ref), domain, grid_name, esm%gcm, esm%scenario)
+                call varslice_init_nml_esm(esm%to_esm_ref, filename, trim(grp_to_esm_ref), domain, grid_name, esm%gcm, esm%scenario)
+                call varslice_init_nml_esm(esm%so_esm_ref, filename, trim(grp_so_esm_ref), domain, grid_name, esm%gcm, esm%scenario)
+                !call varslice_init_nml_esm(esm%zs_esm_ref, filename, trim(grp_zs_esm_ref), domain, grid_name, esm%gcm, esm%scenario)
             end if
             ! ESM historical period
             !if(trim(esm%use_hist)) then
             if (.FALSE.) then
-                call varslice_init_nml_esm(esm%ts_hist, filename,trim(grp_ts_hist), domain,grid_name,esm%gcm,esm%scenario)
-                call varslice_init_nml_esm(esm%pr_hist, filename,trim(grp_pr_hist), domain,grid_name,esm%gcm,esm%scenario)
-                !call varslice_init_nml_esm(esm%zs_hist, filename,trim(grp_zs_hist), domain,grid_name,esm%gcm,esm%scenario)
-                call varslice_init_nml_esm(esm%to_hist, filename,trim(grp_to_hist), domain,grid_name,esm%gcm,esm%scenario)
-                call varslice_init_nml_esm(esm%so_hist, filename,trim(grp_so_hist), domain,grid_name,esm%gcm,esm%scenario)
-                !call varslice_update(esm%zs_hist)
+                call varslice_init_nml_esm(esm%ts_hist, filename,trim(grp_ts_hist), domain, grid_name, esm%gcm, esm%scenario)
+                call varslice_init_nml_esm(esm%pr_hist, filename,trim(grp_pr_hist), domain, grid_name, esm%gcm, esm%scenario)
+                call varslice_init_nml_esm(esm%to_hist, filename,trim(grp_to_hist), domain, grid_name, esm%gcm, esm%scenario)
+                call varslice_init_nml_esm(esm%so_hist, filename,trim(grp_so_hist), domain, grid_name, esm%gcm, esm%scenario)
+                !call varslice_init_nml_esm(esm%zs_hist, filename,trim(grp_zs_hist), domain, grid_name, esm%gcm, esm%scenario)
             end if
             ! ESM projection period
             !if(trim(esm%use_proj)) then
             ! jablasco
-            !if (esm%use_esm .and. .TRUE.) then
-            if (.FALSE.) then    
+            if (use_esm .and. .TRUE.) then
+            !if (.TRUE.) then    
                 call varslice_init_nml_esm(esm%ts_proj, filename,trim(grp_ts_proj), domain,grid_name,esm%gcm,esm%scenario)
                 call varslice_init_nml_esm(esm%pr_proj, filename,trim(grp_pr_proj), domain,grid_name,esm%gcm,esm%scenario)
-                !call varslice_init_nml_esm(esm%zs_proj, filename,trim(grp_zs_proj), domain,grid_name,esm%gcm,esm%scenario)
                 call varslice_init_nml_esm(esm%to_proj, filename,trim(grp_to_proj), domain,grid_name,esm%gcm,esm%scenario)
                 call varslice_init_nml_esm(esm%so_proj, filename,trim(grp_so_proj), domain,grid_name,esm%gcm,esm%scenario)
-                !call varslice_update(esm%zs_proj)
-            end if
+                !call varslice_init_nml_esm(esm%zs_proj, filename,trim(grp_zs_proj), domain, grid_name, esm%gcm, esm%scenario)
+                end if
         end if
 
-        ! Allocate objects
+        ! Allocate objects (use a time independent field)
+        call varslice_update(esm%zs_ref)
         call esm_allocate(esm,size(esm%zs_ref%var,1),size(esm%zs_ref%var,2))
         write(*,*) "dim1, dim2", size(esm%zs_ref%var,1),size(esm%zs_ref%var,2)
 
@@ -514,6 +507,11 @@ contains
         real(wp) :: tmp, lapse
         real(wp) :: rand, year_rand
 
+        ! Initialize anomalies
+        esm%dts_var = 0.0_wp
+        esm%dpr_var = 1.0_wp
+        esm%dto_var = 0.0_wp
+        esm%dso_var = 0.0_wp
             
         ! Obtain reference year climatology
         select case(trim(clim_var))
@@ -564,13 +562,15 @@ contains
                                             z_bed,f_grnd,z_sl,-esm%so_var_ref%z) 
 
             case DEFAULT
-                ! Assume no variabiliy anomaly
-                esm%dts_var = 0.0_wp
-                esm%dpr_var = 1.0_wp
-                esm%dto_var = 0.0_wp
-                esm%dso_var = 0.0_wp
+                ! Assume no variabiliy anomaly (do nothing)
+                
         end select
-    
+   
+        ! remove ronne variability
+        if (.FALSE.) then
+                where(basins .eq. 1) esm%dto_var = 0.0_wp
+        end if
+
         if (use_ref_atm) then
             ! set atmosphere to reference values
             esm%dts_var = 0.0_wp
@@ -626,33 +626,33 @@ contains
         slice_method = "extrap" 
         anomaly = 0.0_wp
             
+        ! Initialize anomalies
+        esm%dts = 0.0_wp
+        esm%dpr = 1.0_wp
+        esm%dto = 0.0_wp
+        esm%dso = 0.0_wp 
+
         select case(trim(esm%ctrl_run_type))
             
             case("ctrl","opt")
-                ! If ctrl or opt, run only reference field.
-                    
-                esm%dts = 0.0_wp
-                esm%dpr = 1.0_wp
-                esm%dto = 0.0_wp
-                esm%dso = 0.0_wp 
+                ! If ctrl or opt, run only reference field. (Do nothing)
             
             case("transient")
                 if (use_esm) then ! Fields loaded from ESM
                     ! === Reference period   ===
-                    ! For now it is the mean over a whole period (check if we want to add monthly data here)
                     ! === Atmospheric fields ===
-                    !call varslice_update(esm%ts_esm_ref,[time_esm_ref(1),time_esm_ref(2)],method="range_mean",rep=1)
-                    !call varslice_update(esm%pr_esm_ref,[time_esm_ref(1),time_esm_ref(2)],method="range_mean",rep=1)
+                    call varslice_update(esm%ts_esm_ref,[time_esm_ref(1),time_esm_ref(2)],method="range_mean",rep=12)
+                    call varslice_update(esm%pr_esm_ref,[time_esm_ref(1),time_esm_ref(2)],method="range_mean",rep=12)
                     ! === Oceanic fields ===
-                    !call varslice_update(esm%to_esm_ref,[time_esm_ref(1),time_esm_ref(2)],method="range_mean",rep=1)
-                    !call varslice_update(esm%so_esm_ref,[time_esm_ref(1),time_esm_ref(2)],method="range_mean",rep=1)
+                    call varslice_update(esm%to_esm_ref,[time_esm_ref(1),time_esm_ref(2)],method="range_mean",rep=1)
+                    call varslice_update(esm%so_esm_ref,[time_esm_ref(1),time_esm_ref(2)],method="range_mean",rep=1)
                         
                     ! Interpolate ocean data to the interior of ice shelves
-                    if (.False.) then
+                    if (.TRUE.) then
                         call ocn_variable_extrapolation(esm%to_esm_ref%var(:,:,:,1),H_ice,basins,-esm%to_esm_ref%z,z_bed)
                         call ocn_variable_extrapolation(esm%so_esm_ref%var(:,:,:,1),H_ice,basins,-esm%so_esm_ref%z,z_bed)
                     end if
-    
+
                     ! === Historical period ===
                     if (time .le. time_hist(2)) then
                         ! === Atmospheric fields === 
@@ -678,13 +678,16 @@ contains
                         
                     ! === Projection period ===
                     else if (time .ge. time_proj(1)) then
+
                         ! === Atmospheric fields ===
-                        call varslice_update(esm%ts_proj, [time],method="extrap",rep=1)
-                        call varslice_update(esm%pr_proj, [time],method="extrap",rep=1)
+                        call varslice_update(esm%ts_proj, [time],method="extrap",rep=12)
+                        call varslice_update(esm%pr_proj, [time],method="extrap",rep=12)
+                        
                         do m = 1, 12
-                            esm%dts(:,:,m) = esm%ts_proj%var(:,:,1,1)-esm%ts_esm_ref%var(:,:,1,1)
-                            esm%dpr(:,:,m) = esm%pr_proj%var(:,:,1,1)/(esm%pr_esm_ref%var(:,:,1,1)+1e-8)
+                            esm%dts(:,:,m) = esm%ts_proj%var(:,:,m,1)-esm%ts_esm_ref%var(:,:,m,1)
+                            esm%dpr(:,:,m) = esm%pr_proj%var(:,:,m,1)/(esm%pr_esm_ref%var(:,:,m,1)+1e-8)
                         end do    
+                        
                         ! ===   Oceanic fields   ===
                         call varslice_update(esm%to_proj,[time],method="extrap",rep=1)
                         call varslice_update(esm%so_proj,[time],method="extrap",rep=1)
@@ -694,6 +697,8 @@ contains
                         call ocn_variable_extrapolation(esm%so_proj%var(:,:,:,1),H_ice,basins,-esm%so_proj%z,z_bed)
                         
                         ! Compute the anomaly at the desired depth level
+                        esm%dto = 0.0_wp
+                        esm%dso = 0.0_wp
                         call marshelf_interp_shelf(esm%dto,mshlf,esm%to_proj%var(:,:,:,1)-esm%to_esm_ref%var(:,:,:,1),H_ice, &
                                                     z_bed,f_grnd,z_sl,-esm%to_esm_ref%z)
                         call marshelf_interp_shelf(esm%dso,mshlf,esm%so_proj%var(:,:,:,1)-esm%so_esm_ref%var(:,:,:,1),H_ice, &
@@ -702,22 +707,21 @@ contains
                     ! === Reference period ===
                     ! Only used if there is a gap between the historical and projection period
                     else if (time .gt. time_hist(2) .and. time .lt. time_proj(1)) then
-                        esm%dts = 0.0_wp
-                        esm%dpr = 1.0_wp
-                        esm%dto = 0.0_wp
-                        esm%dso = 0.0_wp 
+                        ! Do nothing
+
                     end if
+
                 else ! Compute a spatially homogeneous anomaly
                     select case(trim(esm%experiment))
                         case("1pctCO2_transient")
                             ! jablasco: TO DO change
-                            if(time .lt. 2020.0) then
-                                esm%dts = 0.0_wp
-                                esm%dpr = 1.0_wp
-                                esm%dto = 0.0_wp
-                                esm%dso = 0.0_wp
+                            ! sergio test
+                            if(time .lt. 1995.0) then !2020.0) then
+                                ! Do nothing
+
                             else
-                                anomaly = 0.02*(time - 2020.0)
+                                !anomaly = 0.02*(time - 2020.0)
+                                anomaly = (17.0/(2300.0-1995.0))*(time-1995.0)
                                 if (anomaly .ge. esm%dT_lim) anomaly=esm%dT_lim
                                 esm%dts = esm%f_polar*anomaly
                                 esm%dpr = exp(esm%beta_p*esm%f_polar*anomaly)
@@ -751,6 +755,24 @@ contains
         end if
     
         if (.FALSE.) then
+            ! esm ref
+            write(*,*) "minval ts_esm", minval(esm%ts_esm_ref%var(:,:,:,1))
+            write(*,*) "minval pr_esm", minval(esm%pr_esm_ref%var(:,:,:,1))
+            write(*,*) "minval to_esm", minval(esm%to_esm_ref%var(:,:,:,1))
+            write(*,*) "minval so_esm", minval(esm%so_esm_ref%var(:,:,:,1))
+                                  
+            ! proj
+            write(*,*) "minval ts_proj", minval(esm%ts_proj%var(:,:,:,1))
+            write(*,*) "minval pr_proj", minval(esm%pr_proj%var(:,:,:,1))
+            write(*,*) "minval to_proj", minval(esm%to_proj%var(:,:,:,1))
+            write(*,*) "minval so_proj", minval(esm%so_proj%var(:,:,:,1))
+                                
+            ! anomaly
+            write(*,*) "minval dts", minval(esm%dts)
+            write(*,*) "minval dpr", minval(esm%dpr)
+            write(*,*) "minval dto", minval(esm%dto)
+            write(*,*) "minval dso", minval(esm%dso)
+
             ! esm ref
             write(*,*) "maxval ts_esm", maxval(esm%ts_esm_ref%var(:,:,:,1))
             write(*,*) "maxval pr_esm", maxval(esm%pr_esm_ref%var(:,:,:,1))
@@ -1125,8 +1147,8 @@ contains
         allocate(esm%dso_var(nx,ny))
         allocate(esm%t2m_ann(nx,ny))
         allocate(esm%t2m_sum(nx,ny))
-        allocate(esm%pr_ann(nx,ny))
-    
+        allocate(esm%pr_ann(nx,ny))        
+
         return
     
     end subroutine esm_allocate
@@ -1157,3 +1179,4 @@ contains
         end subroutine esm_deallocate
     
 end module esm
+

--- a/libs/marine_shelf.f90
+++ b/libs/marine_shelf.f90
@@ -2268,14 +2268,14 @@ contains
         ! Then we take the ocean information of the grid points which are in contact with mv.
         ! We do the mean of these grid points at different basins and depths and extrapolate them into the ice shelf cavities.
         ! If we reach a depth where there are no surrounding grid points because we have reached a sill, then we do vertical extrapolation inside the ice-shelf cavity from the level above.
-    
-
-
-        implicit none
         
+    
+    
+        implicit none
+            
         real(wp), intent(INOUT) :: var(:,:,:)
         real(wp), intent(IN)    :: H_ice(:,:), basin_mask(:,:), depth(:), z_bed(:,:)
-        
+            
         ! Local variables
         integer :: i, j, k, l
         integer :: nx, ny, nz, nb
@@ -2283,28 +2283,28 @@ contains
         real(wp), allocatable :: mean_var_basin(:,:), npts_basin(:,:)
         ! Define default missing value
         real(wp), parameter :: mv = -9999.0_wp
-        
+            
         nx = size(var, 1)
         ny = size(var, 2)
         nz = size(var, 3)
         nb = maxval(int(basin_mask))
-
+    
         ! Allocate objects
         allocate(mask_border(nx, ny))
         allocate(mean_var_basin(nb, nz))
         allocate(npts_basin(nb, nz))
-        
+            
         ! Initialize variables
         mask_border = 0.0_wp
         mean_var_basin = 0.0_wp
         npts_basin = 0.0_wp
-
+    
         ! 1. Define the mask of grid points with information closest to the ice front or mv.
         ! 0 -> ocean; 2 -> mv or ice; 1 -> ocean point in contact with mv
-        where (H_ice .gt. 0.0_wp .or. var(:,:,1) .eq. mv)
+        where (H_ice .gt. 0.0_wp .or. var(:,:,1) .lt. (mv + 1.0_wp) .or. z_bed .gt. 0.0_wp)
             mask_border = 2.0_wp
         end where
-        
+            
         ! Loop to set mask_border to 1.0_wp for ocean points in contact with mv
         do j = 2, ny-1
         do i = 2, nx-1
@@ -2316,14 +2316,14 @@ contains
             end if
         end do
         end do
-        
+            
         ! 2. Compute the mean of the border by basins and depth.
         do k = 1, nz
         do j = 1, ny
         do i = 1, nx
-            if (mask_border(i, j) .eq. 1.0_wp .and. z_bed(i, j) .lt. depth(k)) then
+            if (mask_border(i, j) .eq. 1.0_wp .and. &
+                abs(z_bed(i, j)) .ge. abs(depth(k)) .and. (var(i, j, k) .gt. mv)) then
                 l = int(basin_mask(i, j))
-                ! ignore basin 0 for the moment (outside of continental-shelf break)
                 if (l .gt. 0) then
                     mean_var_basin(l, k) = mean_var_basin(l, k) + var(i, j, k)
                     npts_basin(l, k)     = npts_basin(l, k) + 1.0_wp
@@ -2332,9 +2332,11 @@ contains
         end do
         end do
         end do
-        
-        mean_var_basin = mean_var_basin / (npts_basin+1e-8)
-        
+            
+        where (npts_basin .gt. 0.0_wp)
+            mean_var_basin = mean_var_basin / npts_basin
+        end where
+            
         ! If the number of points is zero at some depth, set to previous value
         do l = 1, nb
         do k = 2, nz
@@ -2343,7 +2345,7 @@ contains
             end if
         end do
         end do
-        
+            
         ! 3. Assign the mean value by basin
         do k = 1, nz
         do j = 1, ny
@@ -2356,14 +2358,14 @@ contains
         end do
         end do
         end do
-        
-        !if (.TRUE.) then
-        !    write(*,*) "var_max = ",maxval(var(:,:,:))
-        !    write(*,*) "var_min = ",minval(var(:,:,:))
-        !end if
-
+            
+        if (.FALSE.) then
+            write(*,*) "var_max = ",maxval(var(:,:,:))
+            write(*,*) "var_min = ",minval(var(:,:,:))
+        end if
+    
         return
-
+    
     end subroutine ocn_variable_extrapolation
 
 end module marine_shelf

--- a/par/yelmo_Antarctica.nml
+++ b/par/yelmo_Antarctica.nml
@@ -194,7 +194,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_Antarctica_esm.nml
+++ b/par/yelmo_Antarctica_esm.nml
@@ -1,0 +1,587 @@
+&ctrl
+    run_step        = "spinup" 
+/
+
+&esm
+    ! Experiment
+    par_file        = "input/esm/esm_ant.nml"
+    experiment      = "ctrl"            ! "ctrl", "1pctCO2", "lgm", etc.
+    use_esm         = False             ! use ESM snapshots?   
+    esm_name        = "UKESM"           ! esm model, if homogeneous: applied homogeneous forcing
+    
+    ! CMIP conventions
+    write_formatted = False             ! CMIP convention
+    dt_formatted    = 1.0               ! CMIP output timestep
+    
+    ! Climatic variables
+    lapse           = 8.0e-3 6.5e-3     ! lapse rate (sum, ann)
+    f_p             = 0.05              ! Claus-Cl. term
+    f_ocn           = 0.5               ! Oceanic warm fraction. Only used for homogeneous.
+    f_polar         = 1.8               ! Polar amplification
+    dT_threshold    = 1.5               ! Temperature threshold. After this, constant climate.
+
+    ! Source grid
+    grid_src        = "none"        ! Source grid of ESM.
+/
+
+&spinup
+    tstep_method    = "const"           ! "const" (time=time_elapsed) or "cal" (time=time_cal)
+    tstep_const     = 2020              ! Assumed time for "const" method
+    time_init       = 0.0               ! [yr] Starting time (model years)
+    time_end        = 20e3              ! [yr] Ending time (model years)
+    time_equil      = 0.0               ! [yr] Equilibration time
+    dtt             = 10.0              ! [yr] Main loop timestep 
+
+    ! Time intervals (check with ESM forcings)
+    use_hist        = False             ! load historical period. If false, use ref before projection.
+    time_hist       = 1850.0, 1990.0    ! [yr] Year interval used as Historical period
+    time_proj       = 2020.0, 2300.0    ! [yr] Year interval used as Projection period
+    time_ref        = 1990.0, 2019.0    ! [yr] Year interval used as Reference
+                                        ! If "opt" this time interval will be used as optimization 
+    time_esm_ref    = 1990.0, 2019.0    ! [yr] Year interval used as Reference of ESM
+    clim_var        = False             ! include climate variability
+    clim_seed       = 10                ! Randomnes seed
+    kill_shelves    = False             ! Kill ice shelves beyond PD.
+    with_ice_sheet  = True              ! Is the ice sheet active?
+    equil_method    = "opt"             ! "none", "relax", "opt"
+/
+
+&transient
+    tstep_method    = "cal"             ! "const" (time=time_elapsed) or "cal" (time=time_cal)
+    tstep_const     = 2020              ! Assumed time for "const" method
+    time_init       = 1020.0            ! [yr] Starting time (years CE)
+    time_end        = 3500.0            ! [yr] Ending time (years CE)
+    time_equil      = 0.0               ! [yr] Equilibration time
+    dtt             = 1.0               ! [yr] Main loop timestep 
+
+    ! Time intervals (check with ESM forcings)
+    use_hist        = False             ! load historical period. If false, use ref before projection.
+    time_hist       = 1850.0, 1990.0    ! [yr] Year interval used as Historical period
+    time_proj       = 2020.0, 2300.0    ! [yr] Year interval used as Projection period
+    time_ref        = 1990.0, 2019.0    ! [yr] Year interval used as Reference
+                                        ! If "opt" this time interval will be used as optimization 
+    time_esm_ref    = 1990.0, 2019.0    ! [yr] Year interval used as Reference of ESM
+    clim_var        = False             ! include climate variability
+    clim_seed       = 1                 ! Randomnes seed
+    kill_shelves    = False             ! Kill ice shelves beyond PD.
+    with_ice_sheet  = True              ! Is the ice sheet active?
+    equil_method    = "none"            ! "none", "relax", "opt"
+/
+
+&tm_1D
+    method          = "const"           ! "const", "file", "times"
+    dt              = 1.0
+    file            = "input/timeout_ramp_100kyr.txt"
+    times           = -10, -5, 0, 1, 2, 3, 4, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55
+/
+
+&tm_2D
+    method          = "const"           ! "const", "file", "times"
+    dt              = 15e3
+    file            = "input/timeout_ramp_100kyr.txt"
+    times           = 1020
+/
+
+&tm_2Dsm
+    method          = "const"           ! "const", "file", "times"
+    dt              = 2.5e3
+    file            = "input/1pctCO2_out.txt"
+    times           = 1020
+/
+
+&opt
+    opt_cf          = True              ! Should basal friction be optimized?
+    cf_time_init    = 0.0               ! [yr] When should optimization of basal friction start?
+    cf_time_end     = 20e3              ! [yr] When should optimization of basal friction stop?
+    cf_init         = 5e-3              ! Initial value of cf_ref everywhere (negative uses cb_tgt) if not using restart file
+    cf_min          = 1e-5              ! [--] Minimum allowed cf value
+    tau_c           = 500.0             ! [yr] L21: Optimization relaxation timescale 
+    H0              = 100.0             ! [m]  L21: Optimization ice-thickness error scaling 
+ 
+    sigma_err       = 50e3              ! [m] Smoothing radius for error to calculate correction in cf_ref
+    sigma_vel       = 100.0             ! [m/yr] Speed at which smoothing diminishes to zero
+    fill_method     = "cf_min"          ! nearest, analog, target, cf_min
+
+    rel_tau1        = 1.0               ! [yr] Relaxation timescale in time period 1
+    rel_tau2        = 1.0 !6000.0            ! [yr] Relaxation timescale in time period 2
+    rel_time1       = 10.0 !1e3               ! [yr] Time limit for time period 1
+    rel_time2       = 10.0 !1e3               ! [yr] Time limit for time period 2
+    rel_m           = 2.0               ! [--] Non-linear exponent to scale interpolation of rel_tau between time1 and time2 
+
+    opt_tf          = True              ! Should thermal forcing be optimized?
+    tf_time_init    = 0.0               ! [yr] When should optimization of thermal forcing start?
+    tf_time_end     = 20e3               ! [yr] When should optimization of thermal forcing stop?
+    H_grnd_lim      = 0.0               ! [m] Distance from grounding line to consider in terms of thickness above flotation
+    tf_sigma        = 10e3              ! [m] Smoothing radius for error to calculate tf_corr
+    tau_m           = 10.0             ! [yr] Optimization relxation timescale 
+    m_temp          = 10.0              ! [m yr^−1 degC^−1] Optimization scaling value
+    tf_min          = -1.0              ! [degC] Minimum allowed tf_corr value 
+    tf_max          =  1.0              ! [degC] Maximum allowed tf_corr value 
+    tf_basins       = -1                ! Basin numbers to optimize (-1 for all basins)
+    basin_fill      = False    
+/
+
+&yelmo
+    domain          = "Antarctica"
+    grid_name       = "ANT-8KM" 
+    grid_path       = "ice_data/{domain}/{grid_name}/{grid_name}_REGIONS.nc"
+    phys_const      = "Earth"
+    experiment      = "None"            ! "None", "EISMINT1", "MISMIP3D"  to apply special boundary conditions
+    nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
+    nml_ydyn        = "ydyn"
+    nml_ytill       = "ytill"
+    nml_yneff       = "yneff"
+    nml_ymat        = "ymat"
+    nml_ytherm      = "ytherm"
+    nml_masks       = "yelmo_masks"
+    nml_init_topo   = "yelmo_init_topo"
+    nml_data        = "yelmo_data"
+    restart         = "none"
+    restart_z_bed   = True              ! Take z_bed (and z_bed_sd) from restart file
+    restart_H_ice   = True              ! Take H_ice from restart file
+    restart_relax   = 0.0               ! [yrs] Years to relax from restart=>input topography
+    log_timestep    = False 
+    disable_kill    = False             ! Disable automatic kill if unstable
+    zeta_scale      = "exp"             ! "linear", "exp", "tanh"
+    zeta_exp        = 2.0  
+    nz_aa           = 11                ! Vertical resolution in ice
+    dt_method       = 2                 ! 0: no internal timestep, 1: adaptive, cfl, 2: adaptive, pc
+    dt_min          = 0.1               ! [a] Minimum timestep 
+    cfl_max         = 0.5               ! Maximum value is 1.0, lower will be more stable
+    cfl_diff_max    = 0.12              ! Bueler et al (2007), Eq. 25  
+    pc_method       = "AB-SAM"          ! "FE-SBE", "AB-SAM", "HEUN"
+    pc_controller   = "PI42"            ! PI42, H312b, H312PID, H321PID, PID1
+    pc_use_H_pred   = True              ! Use predicted H_ice instead of corrected H_ice 
+    pc_filter_vel   = True              ! Use mean vel. solution of current and previous timestep
+    pc_corr_vel     = False             ! Calculate dynamics again for corrected H_ice
+    pc_n_redo       = 5                 ! How many times can the same iteration be repeated (when high error exists)
+    pc_tol          = 5.0               ! [m/a] Tolerance threshold to redo timestep
+    pc_eps          = 1.0               ! Predictor-corrector tolerance 
+    n_reg           = 0                 ! Number of regions for 1D output
+
+/
+
+&ytopo
+    solver              = "impl-lis"        ! "expl", "impl-lis"
+    surf_gl_method      = 0                 ! 0: binary (max grnd/flt elevation), 1: subgrid average elevation
+    grad_lim            = 0.05               ! [m/m] Maximum allowed sloped in gradient calculations (dz/dx,dH/dx)
+    grad_lim_zb         = 0.05               ! [m/m] Maximum allowed sloped in bed gradient (dzb/dx)
+    dHdt_dyn_lim        = 100.0             ! [m/yr] Maximum allowed ice thickness change due to dynamics
+    margin2nd           = False             ! Apply second-order upwind approximation to gradients at the margin
+    margin_flt_subgrid  = False             ! Allow fractional ice area for floating margins
+    use_bmb             = True              ! Use basal mass balance in mass conservation equation
+    topo_fixed          = False             ! Keep ice thickness fixed, perform other ytopo calculations
+    topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
+    topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
+    topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
+
+    ! === Grounding line ===
+    bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
+    gl_sep              = 2                 ! 1: Linear f_grnd_acx/acy and binary f_grnd, 2: area f_grnd, average to acx/acy
+    gz_nx               = 15                ! [-] Number of interpolation points (nx*nx) to calculate grounded area at grounding line
+
+    ! bmb_gl_method = pmpt
+    dist_grz            = 200.0             ! [km] Radius to consider part of "grounding-line zone" (grz)
+    gz_Hg0              = 0.0               ! Grounding zone, limit of penetration of bmb_grnd 
+    gz_Hg1              = 0.0               ! Grounding zone, limit of penetration of bmb_shlf 
+    
+    ! === discharge mass balance ===
+    dmb_method          = 0                 ! 0: no subgrid discharge, 1: subgrid discharge on
+    dmb_alpha_max       = 60.0              ! [deg] Maximum angle of slope from coast at which to allow discharge
+    dmb_tau             = 100.0             ! [yr]  Discharge timescale
+    dmb_sigma_ref       = 300.0             ! [m]   Reference bed roughness
+    dmb_m_d             = 3.0               ! [-]   Discharge distance scaling exponent
+    dmb_m_r             = 1.0               ! [-]   Discharge resolution scaling exponent
+
+    ! === frontal mass melt ===
+    fmb_method          = 0                 ! 0: prescribe boundary field fmb_shlf; 1: calculate proportional fmb~bmb_shlf.
+    fmb_scale           = 1.0               ! Scaling of fmb ~ scale*bmb, scale=10 suggested by Pollard and DeConto (2016)
+/
+
+&ycalv
+    ! === calving method & law ===
+    use_lsf             = True              ! use level-set method
+    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    calv_flt_method     = "equil"           ! "zero", "simple", "flux", "vm-l19", "kill"
+    calv_grnd_method    = "equil"           ! "zero", "stress-b12"
+    
+    ! === numeric noise === 
+    H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated) - helps with stability, smaller value will lead to more precise summit
+    H_min_flt           = 5.0               ! [m] Minimum ice thickness at floating margin (thinner ice is ablated) - helps with stability
+    sd_min              = 100.0             ! [m] calv_grnd(z_bed_sd <= sd_min) = 0.0 
+    sd_max              = 500.0             ! [m] calv_grnd(z_bed_sd >= sd_max) = calv_max  
+    calv_grnd_max       = 0.0               ! [m/a] Maximum grounded calving rate from high stdev(z_bed)
+    
+    ! === 
+    calv_tau            = 1.0               ! [a] Characteristic calving time
+    calv_thin           = 30.0              ! [m/yr] Calving rate to apply to very thin ice
+    k2                  = 3.2e9             ! [m yr] eigen calving scaling factor (Albrecht et al, 2021 recommend 1e17 m s == 3.2e9 m yr)
+    w2                  = 0.0               ! Weighting coefficient of 2nd principal strain/stress
+    kt_ref              = 0.0025            ! [m yr-1 Pa-1] vm-l19 calving scaling parameter
+    kt_deep             = 0.1               ! [m yr-1 Pa-1] vm-l19 calving scaling parameter for deep ocean
+    tau_ice             = 100.0e3           ! [Pa] Ice strength failure
+
+    ! === threshold method ===
+    Hc_ref_flt          = 200.0             ! [m] Calving limit in ice thickness (thinner ice calves)
+    Hc_ref_grnd         = 100.0             ! [m] Calving limit in grounded ice thickness (thinner ice calves)
+    Hc_ref_thin         = 50.0              ! [m] Reference ice thickness for thin ice calving
+    Hc_deep             = 500.0             ! [m] Calving limit in ice thickness (thinner ice calves)
+    zb_deep_0           = -1000.0           ! [m] Bedrock elevation to begin transition to deep ocean
+    zb_deep_1           = -1500.0           ! [m] Bedrock elevation to end transition to deep ocean
+    zb_sigma            = 0.0               ! [m] Gaussian filtering of bedrock for calving transition to deep ocean
+/
+
+&ydyn
+    solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", "l1l2", "l1l2-noslip"
+    visc_method         = 1               ! 0: constant visc=visc_const, 1: dynamic viscosity
+    visc_const          = 1e7             ! [Pa a] Constant value for viscosity (if visc_method=0)
+    beta_method         = 3               ! 0: constant beta; 1: linear (beta=cb/u0); 2: psuedo-plastic-power; 3: Regularized Coulomb
+    beta_const          = 1e3             ! [Pa a m−1] Constant value of basal friction coefficient to be used
+    beta_q              = 0.2             ! Dragging law exponent 
+    beta_u0             = 100.0           ! [m/a] Regularization term for regularized Coulomb law (beta_method=3)
+    beta_gl_scale       = 0               !  0: beta*beta_gl_f, 1: H_grnd linear scaling, 2: Zstar scaling 
+    beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling 
+    beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
+    taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
+    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim 
+    n_sm_beta           = 0               ! [-] Standard deviation in gridpoints for Gaussian smoothing of beta (0==no smoothing)
+    beta_min            = 100            ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
+    eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
+    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
+    ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
+    ssa_iter_max        = 4               ! Number of maximum allowed iterations over ssa to converge on vel. solution
+    ssa_iter_rel        = 0.7             ! [--] Relaxation fraction [0:1] to stabilize ssa iterations
+    ssa_iter_conv       = 1e-2            ! [--] L2 relative error convergence limit to exit ssa iterations
+    taud_lim            = 2e5             ! [Pa] Maximum allowed driving stress 
+    cb_sia              = 1e-8            ! [m a-1 Pa-1] Bed roughness coefficient for SIA sliding
+    
+/
+
+&ytill
+    method          =  -1               ! -1: set externally; 1: calculate cb_ref online  
+    scale           = "none"            ! "none", "lin", or "exp" : scaling with elevation 
+    is_angle        = False             ! cb_ref is a till strength angle?
+    n_sd            = 10                ! Number of samples over z_bed_sd field
+    f_sed           = 1.0               ! Scaling reduction for thick sediments 
+    sed_min         = 5.0               ! [m] Sediment thickness for no reduction in friction
+    sed_max         = 15.0              ! [m] Sediment thickness for maximum reduction in friction
+    z0              = -250.0            ! [m] Bedrock rel. to sea level, lower limit
+    z1              =  250.0            ! [m] Bedrock rel. to sea level, upper limit
+    cf_min          =  1e-5             ! [-- or deg] Minimum value of cf
+    cf_ref          =  1e-2             ! [-- or deg] Reference/const/max value of cf
+/
+
+&yneff 
+    method          = 2                 ! -1: external N_eff, 0: neff_const, 1: overburden pressure, 2: Leguy param., 3: Till pressure
+    const           = 1e7               ! == rho_ice*g*(eg 1000 m ice thickness)
+    nxi             = 0                 ! 0: no subgrid interpolation, 1: Guassian quadrature of Neff, > 1: interpolate cell H_w to nxi x nxi points.    
+    p               = 1.0               ! *neff_method=2* marine connectivity exponent (0: none, 1: full)
+    H_w_max         = -1.0              ! < 0: Use ytherm.H_w_max; >= 0: Saturation water thickness for neff_method=3.
+    N0              = 1000.0            ! [Pa] *neff_method=3* Reference effective pressure 
+    delta           = 0.8              ! [--] *neff_method=3* Fraction of overburden pressure for saturated till
+    e0              = 0.69              ! [--] *neff_method=3* Reference void ratio at N0 
+    Cc              = 0.12              ! [--] *neff_method=3* Till compressibility    
+    s_const         = 0.5               ! [--] *neff_method=4* Imposed constant till water saturation level    
+/
+
+&ymat
+    flow_law                = "glen"        ! Only "glen" is possible right now
+    rf_method               = 1             ! -1: set externally; 0: rf_const everywhere; 1: standard function 
+    rf_const                = 1e-18         ! [Pa^-3 a^-1]
+    rf_use_eismint2         = False         ! Only applied for rf_method=1
+    rf_with_water           = False         ! Only applied for rf_method=1, scale rf by water content?
+    n_glen                  = 3.0           ! Glen flow law exponent
+    visc_min                = 1e3           ! [Pa a] Minimum allowed viscosity 
+    de_max                  = 0.5           ! [a-1]  Maximum allowed effective strain rate
+    enh_method              = "shear3D"     ! "simple","shear2D", "shear3D", "paleo-shear" 
+    enh_shear               = 1.0
+    enh_stream              = 1.0
+    enh_shlf                = 0.5
+    enh_umin                = 50.0          ! [m/yr] Minimum transition velocity to enh_stream (enh_method="paleo-shear")
+    enh_umax                = 500.0         ! [m/yr] Maximum transition velocity to enh_stream (enh_method="paleo-shear")
+    calc_age                = False         ! Calculate age tracer field?
+    age_iso                 = 0.0
+    tracer_method           = "expl"        ! "expl", "impl": used for age and 'paleo-shear' enh fields
+    tracer_impl_kappa       = 1.5           ! [m2 a-1] Artificial diffusion term for implicit tracer solving 
+    
+/
+
+&ytherm
+    method          = "temp"            ! "fixed", "robin", "temp", "enth"
+    dt_method       = "FE"              ! "FE", "AB", "SAM"
+    solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
+    gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function 
+    use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
+    n_sm_qstrn      = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of strain heating (0==no smoothing)
+    n_sm_qb         = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of basal heating (0==no smoothing)
+    use_const_cp    = False             ! Use specified constant value of heat capacity?
+    const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
+    use_const_kt    = False             ! Use specified constant value of heat conductivity?
+    const_kt        = 6.62e7            ! [J a-1 m-1 K-1] Thermal conductivity [W m-1 K-1 * sec_year] => [J a-1 m-1 K-1]
+    enth_cr         = 1e-3              ! [--] Conductivity ratio for temperate ice (kappa_temp     = enth_cr*kappa_cold)
+    omega_max       = 0.01              ! [--] Maximum allowed water content fraction 
+    till_rate       = 1e-3              ! [m/a] Basal water till drainage rate (water equiv.)
+    H_w_max         = 2.0               ! [m] Maximum limit to basal water layer thickness (water equiv.)
+
+    rock_method     = "active"          ! "equil" (not active bedrock) or "active"
+    nzr_aa          = 5                 ! Number of vertical points in bedrock 
+    zeta_scale_rock = "exp-inv"         ! "linear", "exp-inv"
+    zeta_exp_rock   = 2.0  
+    H_rock          = 2000.0            ! [m] Lithosphere thickness 
+    cp_rock         = 1000.0            ! [J kg-1 K-1] Specific heat capacity of bedrock
+    kt_rock         = 6.3e7             ! [J a-1 m-1 K-1] Thermal conductivity of bedrock [W m-1 K-1 * sec_year] => [J a-1 m-1 K-1]
+/
+
+&yelmo_masks
+    basins_load     = True 
+    basins_path     = "ice_data/{domain}/{grid_name}/{grid_name}_IMBIE2_MASK.nc" ! IMBIE 
+    basins_nms      = "SubBasins_extrap" "Basins_extrap"
+    regions_load    = True 
+    regions_path    = "ice_data/{domain}/{grid_name}/{grid_name}_REGIONS.nc"
+    regions_nms     = "mask" "None"
+/
+
+&yelmo_init_topo
+    init_topo_load    = True
+    init_topo_path    = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO_BedMachineAntarctica-v3.nc"
+    init_topo_names   = "thickness" "bed" "errbed" "surface"      ! Ice thickness, bedrock elevation, bedrock noise, surface elevation
+    init_topo_state   = 0                                       ! 0: from file, 1: ice-free, 2: ice-free, rebounded 
+    z_bed_f_sd        = 0.0                                     ! Scaling fraction to modify z_bed = z_bed + f_sd*z_bed_sd
+    smooth_H_ice      = 0.0                                     ! Smooth ice thickness field at loading time, with sigma=N*dx
+    smooth_z_bed      = 0.0                                     ! Smooth bedrock field at loading time, with sigma=N*dx
+    
+/
+
+&yelmo_data 
+    pd_topo_load      = True 
+    pd_topo_path      = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO_BedMachineAntarctica-v3.nc"
+    pd_topo_names     = "thickness" "bed" "errbed" "surface" "mask" ! Ice thickness, bedrock elevation, bedrock noise, surface elevation
+    pd_tsrf_load      = True 
+    pd_tsrf_path      = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_RACMO23-VW23.nc"
+    pd_tsrf_name      = "T_srf"                      ! Surface temperature (or near-surface temperature)
+    pd_tsrf_monthly   = True
+    pd_smb_load       = True 
+    pd_smb_path       = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_RACMO23-VW23.nc"
+    pd_smb_name       = "smb"                        ! Surface mass balance 
+    pd_smb_monthly    = True 
+    pd_vel_load       = True 
+    pd_vel_path       = "ice_data/{domain}/{grid_name}/{grid_name}_VEL-R11-2.nc"
+    pd_vel_names      = "ux_srf" "uy_srf"            ! Surface velocity 
+    pd_age_load       = False 
+    pd_age_path       = "input/{domain}/{grid_name}/{grid_name}_STRAT-M15.nc"
+    pd_age_names      = "age_iso" "depth_iso"        ! ages of isochrones; depth of isochrones 
+
+/
+
+! ===== EXTERNAL LIBRARIES =====
+
+&smbpal
+    const_insol = True
+    const_kabp  = 0.0
+    insol_fldr  = "input"
+    abl_method  = "itm"   ! "itm" or "pdd"
+    sigma_snow  = 5.0     ! Standard deviation of temperature [K] over ice and snow
+    sigma_melt  = 5.0     ! Standard deviation of temperature [K] in ablation zone
+    sigma_land  = 5.0     ! Standard deviation of temperature [K] over land 
+    
+    sf_a        = 0.273   ! Snow fraction function (parameter a)
+    sf_b        = 273.6   ! Snow fraction function (parameter b)
+    firn_fac    = 0.0266  ! Reduction in surface temp versus melting [K/mm w.e.]
+
+    mm_snow = 3.0         ! PDD snow melt factor [mm w.e./K-d]
+    mm_ice  = 8.0         ! PDD ice melt factor  [mm w.e./K-d]
+    
+/
+
+&itm
+        
+    H_snow_max      =  5.0e3         ! Maximum allowed snowpack thickness [mm w.e.]
+    Pmaxfrac        =  0.6           ! Refreezing factor 
+
+    ! ## ITM 
+    trans_a         =  0.46 
+    trans_b         =  6e-5
+    trans_c         =  0.01
+    itm_c           = -55.0
+    itm_t           =  10.0
+    itm_b           =  3.0 
+    itm_lat0        =  -60.0 
+
+    ! ## Surface albedo
+    alb_snow_dry       =  0.8
+    alb_snow_wet       =  0.65
+    alb_ice            =  0.70
+    alb_land           =  0.2
+    alb_forest         =  0.1
+    alb_ocean          =  0.1
+    H_snow_crit_desert =  10.0
+    H_snow_crit_forest = 100.0
+    melt_crit          =   0.5      ! Critical melt rate to reduce snow albedo [mm/day]
+
+/
+
+&marine_shelf
+    bmb_method      = "quad-nl" ! "pico", "anom", "lin", "quad", "quad-nl", "*-slope"
+    tf_method       = 1             ! 0: tf defined externally, 1: calculate as T_shlf-t_fp_shlf, 2: use dT_shlf
+    interp_depth    = "shlf"        ! "shlf", "bed", "const"
+    interp_method   = "interp"      ! "mean", "layer", "interp" ! Same method is used for salinity
+    find_ocean      = True          ! Find which points are connected to open ocean (ie, ignore subglacial lakes)
+    restart         = "none"        ! Load fields from a restart file?
+    
+    corr_method     = "bmb"          ! "tf": corrected tf basin, "bmb": corrected bmb basin, "tf-ant": use values in tf_corr_ant parameter section
+    basin_number    = 12
+    basin_bmb_corr  = 0.0           ! -1.0  -1.0 -1.0 [corrected bmb m/yr; -: melting, +: accretion]
+    basin_tf_corr   = 0.5 -0.17 -0.31 -0.24 0.31 0.25 -0.15 -0.1 -0.74 -0.62 -0.1 -2.5 -2.6 -1.67 0.0 -1.37 0.0 0.75 0.71
+    tf_correction   = False
+    tf_path         = "ice_data/ISMIP6/{domain}/{grid_name}/Ocean/{grid_name}_OCEAN_ISMIP6_J20.nc"
+    tf_name         = "dT_nl"
+ 
+    bmb_max         = 0.0           ! [m/a] Maximum allowed bmb value (eg, for no refreezing, set bmb_max=0.0) 
+    
+    ! Deep ocean bmb 
+    c_deep          = -10.0         ! [m/yr] Melt rate in deep ocean, should be negative but not huge
+    depth_deep      = 2000.0        ! [m] Depth at which deep ocean is assumed
+    depth_const     = 1000.0        ! [m] Constant shelf depth for interp_depth=const
+    depth_min       = 1100.0        ! [m] interp_method=mean, min depth to include
+    depth_max       = 1500.0        ! [m] interp_method=mean, max depth to include
+    
+    ! Freezing point coefficients
+    lambda1         = -0.0575       ! [degC PSU−1] Liquidus slope
+    lambda2         = 0.0832        ! [degC] Liquidus intercept 
+    lambda3         = 7.59e-4       ! [degC m−1] Liquidus pressure coefficient
+
+    ! bmb_method == [lin,quad,quad-nl] 
+    gamma_lin       = 630.0         ! [m/yr] Linear heat excange velocity. Favier et al., (2019) suggest 630.
+    gamma_quad      = 14.5e3       ! [m/yr] Quadratic heat exchange velocity. Jourdain et al. (2020) suggest 11100.
+    gamma_quad_nl   = 14.5e3        ! [m/yr] Quadratic non-local heat exchange velocity. Jourdain et al. (2020) suggest 14500.
+    gamma_prime     = 100.0         ! [-] Scalar when '*-slope' method is used
+
+    ! bmb_method == anom
+    kappa_grz       = 10.0          ! [m/yr K-1] Heat flux coefficient [kappa*dT]
+    c_grz           = 1.0           ! [-] bmb_ref scalar [c_grz*bmb_ref]
+    f_grz_shlf      = 10.0          ! [-] Ratio of grz melt to shelf melt
+    grz_length      = 32.0          ! [km] Length scale of assumed grounding zone
+
+    ! bmb_method == anom, bmb_ref parameters 
+    use_obs         = False         ! Load obs for bmb_ref
+    obs_path        = "ice_data/{domain}/{grid_name}/{grid_name}_BMELT-R13.nc"
+    obs_name        = "bm_eq_reese"
+    obs_scale       = 1.0           ! [-] bmb_ref = obs_scale*bmb_obs
+    obs_lim         = 100.0         ! [m/yr] Maximum magnitude of bmb_ref
+    basin_name      = "none"        !"northwest" "northeast" "east"
+    basin_bmb       = 0.0           !        -1.0       -1.0   -1.0
+    
+/
+
+&tf_corr_ant
+    ronne   = 0.0                   ! [K] tf_corr for ronne basin (basin=1)
+    ross    = 0.0                   ! [K] tf_corr for ross basin (basin=12)
+    pine    = 0.0                   ! [K] tf_corr for pine island (basin=14)
+    abbott  = 0.0                   ! [K] tf_corr for Abbott glacier (basin=15)
+/
+
+
+&pico
+    n_box          = 5.0        ! Maximum number of boxes in PICO.  
+    a_pico         = -0.0572    ! Salinity coefficient of freezing equation [ºC/PSU]. Reese et al., (2018) suggest −0.0572.
+    b_pico         = 0.0788     ! Constant coefficient of freezing equation [ºC]. Reese et al., (2018) suggest 0.0788.
+    c_pico         = 7.77e-8    ! Pressure coefficient of freezing equation [ºC/Pa]. Reese et al., (2018) suggest 7.77e-8.
+    alpha_pico     = 7.5e-5     ! Thermal expansion coefficien [1/ºC]. Reese et al., (2018) suggest 7.5e-5.
+    beta_pico      = 7.7e-4     ! Salt contraction coefficient [1/PSU]. Reese et al., (2018) suggest 7.7e-4.
+    rho_star       = 1033.0     ! Reference density [kg/m3]. Reese et al., (2018) suggest 1033.0.
+    gamma_tstar    = 1500.0      ! Effective turbulent temperature exchange velocity [m/yr]. Reese et al., (2018) uses 630.0 and suggest 600-1000.
+    C_over         = 2.0        ! Overturning strength [Sv m3/kg]. Reese et al., (2018) suggest 1.0.
+
+/
+
+&sediments
+    use_obs   = False
+    obs_path  = "ice_data/{domain}/{grid_name}/{grid_name}_SED-L97.nc"
+    obs_name  = "z_sed"
+
+/
+
+&geothermal
+    use_obs   = True 
+    obs_path  = "ice_data/{domain}/{grid_name}/{grid_name}_GHF-M17.nc"
+    obs_name  = "ghf"
+    ghf_const = 50.0           ! [mW/m^2]
+
+/
+
+&isos
+    ! Options
+    heterogeneous_ssh = .true.      ! Sea level varies spatially?
+    interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
+    correct_distortion = .false.    ! Account for distortion of projection?
+    method          = 2             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
+    dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
+    ! Jan: change dt_prog to 0.1 (up to 0.02)
+    dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
+    pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
+                                    ! of 2 multiplied by the resolution)
+
+
+    ! Rheology methods
+    mantle = "rheology_file"        ! Choose mantle viscosity field, options:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "rheology_file"   ! Choose lithospheric thickness field:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "parallel"        ! "parallel" or "equalized"
+    lumping     = "min"             ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
+    
+    ! Rheology parameters
+    nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
+    zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
+                                    ! Only used if layering="equalized". First value 
+                                    ! overwritten if visc_method="rheology_file".
+    viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
+                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                    ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
+    rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
+                                ! and mantle viscosity
+
+    ! Physical constants
+    E               = 66.0          ! [GPa] Young modulus
+    nu              = 0.28          ! [-] Poisson ratio
+    rho_ice         = 910.          ! [kg/m^3]
+    rho_seawater    = 1028.0        ! [kg/m^3]
+    rho_water       = 1000.0        ! [kg/m^3]
+    rho_uppermantle = 3400.0        ! [kg/m^3]
+    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
+                                    ! displacement from the viscous one
+    g               = 9.81          ! [m/s^2]
+    r_earth         = 6.378e3       ! [km] Earth radius, Coulon et al. (2021)
+    m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
+
+    ! Files
+    restart = "None"
+    mask_file = "None"
+    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-8KM_GIA_HR24.nc"
+    litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
+    log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
+    stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
+
+/
+
+&barysealevel
+    method      = "fastiso" ! "const": BSL = bsl_init throughout sim
+                            ! "file": BSL = time series provided from sl_path
+                            ! "fastiso": BSL = sum of contributions from fastiso domains
+    bsl_init    = 0.0       ! [m] BSL relative to present day
+    sl_path     = "none"    ! Input time series filename
+    sl_name     = "none"    ! Variable name in netcdf file, if relevant
+    A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
+    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc"
+    restart    = "None"
+/

--- a/par/yelmo_Antarctica_esm.nml
+++ b/par/yelmo_Antarctica_esm.nml
@@ -249,7 +249,8 @@
     beta_min            = 100            ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 4               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_Antarctica_nudge.nml
+++ b/par/yelmo_Antarctica_nudge.nml
@@ -1,0 +1,590 @@
+&ctrl
+    run_step        = "spinup" 
+/
+
+&esm
+    ! Experiment
+    par_file        = "input/esm/esm_nudge.nml"
+    experiment      = "ctrl"            ! "ctrl", "1pctCO2", "lgm", etc.
+    use_esm         = True             ! use ESM snapshots?   
+    esm_name        = "UKESM"           ! esm model, if homogeneous: applied homogeneous forcing
+    
+    ! CMIP conventions
+    write_formatted = False             ! CMIP convention
+    dt_formatted    = 1.0               ! CMIP output timestep
+    
+    ! Climatic variables
+    lapse           = 8.0e-3 6.5e-3     ! lapse rate (sum, ann)
+    f_p             = 0.05              ! Claus-Cl. term
+    f_ocn           = 0.5               ! Oceanic warm fraction. Only used for homogeneous.
+    f_polar         = 1.8               ! Polar amplification
+    dT_threshold    = 1.5               ! Temperature threshold. After this, constant climate.
+
+    ! Source grid
+    grid_src        = "none"        ! Source grid of ESM.
+/
+
+&spinup
+    tstep_method    = "const"           ! "const" (time=time_elapsed) or "cal" (time=time_cal)
+    tstep_const     = 2020              ! Assumed time for "const" method
+    time_init       = 0.0               ! [yr] Starting time (model years)
+    time_end        = 20e3              ! [yr] Ending time (model years)
+    time_equil      = 0.0               ! [yr] Equilibration time
+    dtt             = 10.0              ! [yr] Main loop timestep 
+
+    ! Time intervals (check with ESM forcings)
+    use_hist        = False             ! load historical period. If false, use ref before projection.
+    time_hist       = 1850.0, 1990.0    ! [yr] Year interval used as Historical period
+    time_proj       = 2020.0, 2300.0    ! [yr] Year interval used as Projection period
+    time_ref        = 1990.0, 2019.0    ! [yr] Year interval used as Reference
+                                        ! If "opt" this time interval will be used as optimization 
+    time_esm_ref    = 1990.0, 2019.0    ! [yr] Year interval used as Reference of ESM
+    clim_var        = False             ! include climate variability
+    clim_seed       = 10                ! Randomnes seed
+    kill_shelves    = False             ! Kill ice shelves beyond PD.
+    with_ice_sheet  = True              ! Is the ice sheet active?
+    equil_method    = "opt"             ! "none", "relax", "opt"
+/
+
+&transient
+    tstep_method    = "cal"             ! "const" (time=time_elapsed) or "cal" (time=time_cal)
+    tstep_const     = 4500.0            ! Assumed time for "const" method
+    time_init       = 4501.0            ! [yr] Starting time (years CE)
+    time_end        = 5000.0            ! [yr] Ending time (years CE)
+    time_equil      = 4500.0            ! [yr] Equilibration time
+    dtt             = 1.0               ! [yr] Main loop timestep 
+
+    ! Time intervals climatology
+    time_ref        = 1990.0, 2019.0    ! [yr] Year interval used as Reference
+                                        ! If "opt" this time interval will be used as optimization 
+    
+    ! Time intervals ESM
+    time_esm_ref    = 4501.0, 5000.0    ! [yr] Year interval used as Reference of ESM
+    use_hist        = False             ! load historical period. If false, dont use snapshots for historical.
+    time_hist       = 1950.0, 1990.0    ! [yr] Year interval used as Historical period
+    use_proj        = True             ! load projection period. If false, dont use snapshots for projection projection.
+    time_proj       = 4501.0, 5000.0    ! [yr] Year interval used as Projection period
+    clim_var        = False             ! include climate variability
+    clim_seed       = 1                 ! Randomnes seed
+    kill_shelves    = False             ! Kill ice shelves beyond PD.
+    with_ice_sheet  = True              ! Is the ice sheet active?
+    equil_method    = "none"            ! "none", "relax", "opt"
+/
+
+&tm_1D
+    method          = "const"           ! "const", "file", "times"
+    dt              = 1.0
+    file            = "input/timeout_ramp_100kyr.txt"
+    times           = -10, -5, 0, 1, 2, 3, 4, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55
+/
+
+&tm_2D
+    method          = "times"           ! "const", "file", "times"
+    dt              = 5e3
+    file            = "input/timeout_ramp_100kyr.txt"
+    times           = 4501,5000
+/
+
+&tm_2Dsm
+    method          = "times"           ! "const", "file", "times"
+    dt              = 1.0
+    file            = "input/1pctCO2_out.txt"
+    times           = 4501,4550,4600,4650,4700,4750,4800,4850,4900,4950,5000
+/
+
+&opt
+    opt_cf          = True              ! Should basal friction be optimized?
+    cf_time_init    = 0.0               ! [yr] When should optimization of basal friction start?
+    cf_time_end     = 20e3              ! [yr] When should optimization of basal friction stop?
+    cf_init         = 5e-3              ! Initial value of cf_ref everywhere (negative uses cb_tgt) if not using restart file
+    cf_min          = 1e-5              ! [--] Minimum allowed cf value
+    tau_c           = 500.0             ! [yr] L21: Optimization relaxation timescale 
+    H0              = 100.0             ! [m]  L21: Optimization ice-thickness error scaling 
+ 
+    sigma_err       = 50e3              ! [m] Smoothing radius for error to calculate correction in cf_ref
+    sigma_vel       = 100.0             ! [m/yr] Speed at which smoothing diminishes to zero
+    fill_method     = "cf_min"          ! nearest, analog, target, cf_min
+
+    rel_tau1        = 1.0               ! [yr] Relaxation timescale in time period 1
+    rel_tau2        = 6000.0            ! [yr] Relaxation timescale in time period 2
+    rel_time1       = 1e3               ! [yr] Time limit for time period 1
+    rel_time2       = 1e3               ! [yr] Time limit for time period 2
+    rel_m           = 2.0               ! [--] Non-linear exponent to scale interpolation of rel_tau between time1 and time2 
+
+    opt_tf          = True              ! Should thermal forcing be optimized?
+    tf_time_init    = 0.0               ! [yr] When should optimization of thermal forcing start?
+    tf_time_end     = 20e3               ! [yr] When should optimization of thermal forcing stop?
+    H_grnd_lim      = 0.0               ! [m] Distance from grounding line to consider in terms of thickness above flotation
+    tf_sigma        = 10e3              ! [m] Smoothing radius for error to calculate tf_corr
+    tau_m           = 10.0             ! [yr] Optimization relxation timescale 
+    m_temp          = 10.0              ! [m yr^−1 degC^−1] Optimization scaling value
+    tf_min          = -3.0              ! [degC] Minimum allowed tf_corr value 
+    tf_max          =  1.0              ! [degC] Maximum allowed tf_corr value 
+    tf_basins       = -1                ! Basin numbers to optimize (-1 for all basins)
+    basin_fill      = False    
+/
+
+&yelmo
+    domain          = "Antarctica"
+    grid_name       = "ANT-16KM" 
+    grid_path       = "ice_data/{domain}/{grid_name}/{grid_name}_REGIONS.nc"
+    phys_const      = "Earth"
+    experiment      = "None"            ! "None", "EISMINT1", "MISMIP3D"  to apply special boundary conditions
+    nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
+    nml_ydyn        = "ydyn"
+    nml_ytill       = "ytill"
+    nml_yneff       = "yneff"
+    nml_ymat        = "ymat"
+    nml_ytherm      = "ytherm"
+    nml_masks       = "yelmo_masks"
+    nml_init_topo   = "yelmo_init_topo"
+    nml_data        = "yelmo_data"
+    restart         = "none"
+    restart_z_bed   = True              ! Take z_bed (and z_bed_sd) from restart file
+    restart_H_ice   = True              ! Take H_ice from restart file
+    restart_relax   = 0.0               ! [yrs] Years to relax from restart=>input topography
+    log_timestep    = False 
+    disable_kill    = False             ! Disable automatic kill if unstable
+    zeta_scale      = "exp"             ! "linear", "exp", "tanh"
+    zeta_exp        = 2.0  
+    nz_aa           = 11                ! Vertical resolution in ice
+    dt_method       = 2                 ! 0: no internal timestep, 1: adaptive, cfl, 2: adaptive, pc
+    dt_min          = 0.1               ! [a] Minimum timestep 
+    cfl_max         = 0.5               ! Maximum value is 1.0, lower will be more stable
+    cfl_diff_max    = 0.12              ! Bueler et al (2007), Eq. 25  
+    pc_method       = "AB-SAM"          ! "FE-SBE", "AB-SAM", "HEUN"
+    pc_controller   = "PI42"            ! PI42, H312b, H312PID, H321PID, PID1
+    pc_use_H_pred   = True              ! Use predicted H_ice instead of corrected H_ice 
+    pc_filter_vel   = True              ! Use mean vel. solution of current and previous timestep
+    pc_corr_vel     = False             ! Calculate dynamics again for corrected H_ice
+    pc_n_redo       = 5                 ! How many times can the same iteration be repeated (when high error exists)
+    pc_tol          = 5.0               ! [m/a] Tolerance threshold to redo timestep
+    pc_eps          = 1.0               ! Predictor-corrector tolerance 
+    n_reg           = 0                 ! Number of regions for 1D output
+
+/
+
+&ytopo
+    solver              = "impl-lis"        ! "expl", "impl-lis"
+    surf_gl_method      = 0                 ! 0: binary (max grnd/flt elevation), 1: subgrid average elevation
+    grad_lim            = 0.05               ! [m/m] Maximum allowed sloped in gradient calculations (dz/dx,dH/dx)
+    grad_lim_zb         = 0.05               ! [m/m] Maximum allowed sloped in bed gradient (dzb/dx)
+    dHdt_dyn_lim        = 100.0             ! [m/yr] Maximum allowed ice thickness change due to dynamics
+    margin2nd           = False             ! Apply second-order upwind approximation to gradients at the margin
+    margin_flt_subgrid  = False             ! Allow fractional ice area for floating margins
+    use_bmb             = True              ! Use basal mass balance in mass conservation equation
+    topo_fixed          = False             ! Keep ice thickness fixed, perform other ytopo calculations
+    topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
+    topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
+    topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
+
+    ! === Grounding line ===
+    bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
+    gl_sep              = 2                 ! 1: Linear f_grnd_acx/acy and binary f_grnd, 2: area f_grnd, average to acx/acy
+    gz_nx               = 15                ! [-] Number of interpolation points (nx*nx) to calculate grounded area at grounding line
+
+    ! bmb_gl_method = pmpt
+    dist_grz            = 200.0             ! [km] Radius to consider part of "grounding-line zone" (grz)
+    gz_Hg0              = 0.0               ! Grounding zone, limit of penetration of bmb_grnd 
+    gz_Hg1              = 0.0               ! Grounding zone, limit of penetration of bmb_shlf 
+    
+    ! === discharge mass balance ===
+    dmb_method          = 0                 ! 0: no subgrid discharge, 1: subgrid discharge on
+    dmb_alpha_max       = 60.0              ! [deg] Maximum angle of slope from coast at which to allow discharge
+    dmb_tau             = 100.0             ! [yr]  Discharge timescale
+    dmb_sigma_ref       = 300.0             ! [m]   Reference bed roughness
+    dmb_m_d             = 3.0               ! [-]   Discharge distance scaling exponent
+    dmb_m_r             = 1.0               ! [-]   Discharge resolution scaling exponent
+
+    ! === frontal mass melt ===
+    fmb_method          = 0                 ! 0: prescribe boundary field fmb_shlf; 1: calculate proportional fmb~bmb_shlf.
+    fmb_scale           = 1.0               ! Scaling of fmb ~ scale*bmb, scale=10 suggested by Pollard and DeConto (2016)
+/
+
+&ycalv
+    ! === calving method & law ===
+    use_lsf             = True              ! use level-set method
+    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    calv_flt_method     = "equil"           ! "zero", "simple", "flux", "vm-l19", "kill"
+    calv_grnd_method    = "equil"           ! "zero", "stress-b12"
+    
+    ! === numeric noise === 
+    H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated) - helps with stability, smaller value will lead to more precise summit
+    H_min_flt           = 5.0               ! [m] Minimum ice thickness at floating margin (thinner ice is ablated) - helps with stability
+    sd_min              = 100.0             ! [m] calv_grnd(z_bed_sd <= sd_min) = 0.0 
+    sd_max              = 500.0             ! [m] calv_grnd(z_bed_sd >= sd_max) = calv_max  
+    calv_grnd_max       = 0.0               ! [m/a] Maximum grounded calving rate from high stdev(z_bed)
+    
+    ! === 
+    calv_tau            = 1.0               ! [a] Characteristic calving time
+    calv_thin           = 30.0              ! [m/yr] Calving rate to apply to very thin ice
+    k2                  = 3.2e9             ! [m yr] eigen calving scaling factor (Albrecht et al, 2021 recommend 1e17 m s == 3.2e9 m yr)
+    w2                  = 0.0               ! Weighting coefficient of 2nd principal strain/stress
+    kt_ref              = 0.0025            ! [m yr-1 Pa-1] vm-l19 calving scaling parameter
+    kt_deep             = 0.1               ! [m yr-1 Pa-1] vm-l19 calving scaling parameter for deep ocean
+    tau_ice             = 100.0e3           ! [Pa] Ice strength failure
+
+    ! === threshold method ===
+    Hc_ref_flt          = 200.0             ! [m] Calving limit in ice thickness (thinner ice calves)
+    Hc_ref_grnd         = 100.0             ! [m] Calving limit in grounded ice thickness (thinner ice calves)
+    Hc_ref_thin         = 50.0              ! [m] Reference ice thickness for thin ice calving
+    Hc_deep             = 500.0             ! [m] Calving limit in ice thickness (thinner ice calves)
+    zb_deep_0           = -1000.0           ! [m] Bedrock elevation to begin transition to deep ocean
+    zb_deep_1           = -1500.0           ! [m] Bedrock elevation to end transition to deep ocean
+    zb_sigma            = 0.0               ! [m] Gaussian filtering of bedrock for calving transition to deep ocean
+/
+
+&ydyn
+    solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", "l1l2", "l1l2-noslip"
+    visc_method         = 1               ! 0: constant visc=visc_const, 1: dynamic viscosity
+    visc_const          = 1e7             ! [Pa a] Constant value for viscosity (if visc_method=0)
+    beta_method         = 3               ! 0: constant beta; 1: linear (beta=cb/u0); 2: psuedo-plastic-power; 3: Regularized Coulomb
+    beta_const          = 1e3             ! [Pa a m−1] Constant value of basal friction coefficient to be used
+    beta_q              = 0.2             ! Dragging law exponent 
+    beta_u0             = 100.0           ! [m/a] Regularization term for regularized Coulomb law (beta_method=3)
+    beta_gl_scale       = 0               !  0: beta*beta_gl_f, 1: H_grnd linear scaling, 2: Zstar scaling 
+    beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling 
+    beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
+    taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
+    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim 
+    n_sm_beta           = 0               ! [-] Standard deviation in gridpoints for Gaussian smoothing of beta (0==no smoothing)
+    beta_min            = 100            ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
+    eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
+    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
+    ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
+    ssa_iter_max        = 4               ! Number of maximum allowed iterations over ssa to converge on vel. solution
+    ssa_iter_rel        = 0.7             ! [--] Relaxation fraction [0:1] to stabilize ssa iterations
+    ssa_iter_conv       = 1e-2            ! [--] L2 relative error convergence limit to exit ssa iterations
+    taud_lim            = 2e5             ! [Pa] Maximum allowed driving stress 
+    cb_sia              = 1e-8            ! [m a-1 Pa-1] Bed roughness coefficient for SIA sliding
+    
+/
+
+&ytill
+    method          =  -1               ! -1: set externally; 1: calculate cb_ref online  
+    scale           = "none"            ! "none", "lin", or "exp" : scaling with elevation 
+    is_angle        = False             ! cb_ref is a till strength angle?
+    n_sd            = 10                ! Number of samples over z_bed_sd field
+    f_sed           = 1.0               ! Scaling reduction for thick sediments 
+    sed_min         = 5.0               ! [m] Sediment thickness for no reduction in friction
+    sed_max         = 15.0              ! [m] Sediment thickness for maximum reduction in friction
+    z0              = -250.0            ! [m] Bedrock rel. to sea level, lower limit
+    z1              =  250.0            ! [m] Bedrock rel. to sea level, upper limit
+    cf_min          =  1e-5             ! [-- or deg] Minimum value of cf
+    cf_ref          =  1e-2             ! [-- or deg] Reference/const/max value of cf
+/
+
+&yneff 
+    method          = 2                 ! -1: external N_eff, 0: neff_const, 1: overburden pressure, 2: Leguy param., 3: Till pressure
+    const           = 1e7               ! == rho_ice*g*(eg 1000 m ice thickness)
+    nxi             = 0                 ! 0: no subgrid interpolation, 1: Guassian quadrature of Neff, > 1: interpolate cell H_w to nxi x nxi points.    
+    p               = 1.0               ! *neff_method=2* marine connectivity exponent (0: none, 1: full)
+    H_w_max         = -1.0              ! < 0: Use ytherm.H_w_max; >= 0: Saturation water thickness for neff_method=3.
+    N0              = 1000.0            ! [Pa] *neff_method=3* Reference effective pressure 
+    delta           = 0.8              ! [--] *neff_method=3* Fraction of overburden pressure for saturated till
+    e0              = 0.69              ! [--] *neff_method=3* Reference void ratio at N0 
+    Cc              = 0.12              ! [--] *neff_method=3* Till compressibility    
+    s_const         = 0.5               ! [--] *neff_method=4* Imposed constant till water saturation level    
+/
+
+&ymat
+    flow_law                = "glen"        ! Only "glen" is possible right now
+    rf_method               = 1             ! -1: set externally; 0: rf_const everywhere; 1: standard function 
+    rf_const                = 1e-18         ! [Pa^-3 a^-1]
+    rf_use_eismint2         = False         ! Only applied for rf_method=1
+    rf_with_water           = False         ! Only applied for rf_method=1, scale rf by water content?
+    n_glen                  = 3.0           ! Glen flow law exponent
+    visc_min                = 1e3           ! [Pa a] Minimum allowed viscosity 
+    de_max                  = 0.5           ! [a-1]  Maximum allowed effective strain rate
+    enh_method              = "shear3D"     ! "simple","shear2D", "shear3D", "paleo-shear" 
+    enh_shear               = 1.0
+    enh_stream              = 1.0
+    enh_shlf                = 0.5
+    enh_umin                = 50.0          ! [m/yr] Minimum transition velocity to enh_stream (enh_method="paleo-shear")
+    enh_umax                = 500.0         ! [m/yr] Maximum transition velocity to enh_stream (enh_method="paleo-shear")
+    calc_age                = False         ! Calculate age tracer field?
+    age_iso                 = 0.0
+    tracer_method           = "expl"        ! "expl", "impl": used for age and 'paleo-shear' enh fields
+    tracer_impl_kappa       = 1.5           ! [m2 a-1] Artificial diffusion term for implicit tracer solving 
+    
+/
+
+&ytherm
+    method          = "temp"            ! "fixed", "robin", "temp", "enth"
+    dt_method       = "FE"              ! "FE", "AB", "SAM"
+    solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
+    gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function 
+    use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
+    n_sm_qstrn      = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of strain heating (0==no smoothing)
+    n_sm_qb         = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of basal heating (0==no smoothing)
+    use_const_cp    = False             ! Use specified constant value of heat capacity?
+    const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
+    use_const_kt    = False             ! Use specified constant value of heat conductivity?
+    const_kt        = 6.62e7            ! [J a-1 m-1 K-1] Thermal conductivity [W m-1 K-1 * sec_year] => [J a-1 m-1 K-1]
+    enth_cr         = 1e-3              ! [--] Conductivity ratio for temperate ice (kappa_temp     = enth_cr*kappa_cold)
+    omega_max       = 0.01              ! [--] Maximum allowed water content fraction 
+    till_rate       = 1e-3              ! [m/a] Basal water till drainage rate (water equiv.)
+    H_w_max         = 2.0               ! [m] Maximum limit to basal water layer thickness (water equiv.)
+
+    rock_method     = "active"          ! "equil" (not active bedrock) or "active"
+    nzr_aa          = 5                 ! Number of vertical points in bedrock 
+    zeta_scale_rock = "exp-inv"         ! "linear", "exp-inv"
+    zeta_exp_rock   = 2.0  
+    H_rock          = 2000.0            ! [m] Lithosphere thickness 
+    cp_rock         = 1000.0            ! [J kg-1 K-1] Specific heat capacity of bedrock
+    kt_rock         = 6.3e7             ! [J a-1 m-1 K-1] Thermal conductivity of bedrock [W m-1 K-1 * sec_year] => [J a-1 m-1 K-1]
+/
+
+&yelmo_masks
+    basins_load     = True 
+    basins_path     = "ice_data/{domain}/{grid_name}/{grid_name}_BASINS-nasa.nc" ! IMBIE 
+    basins_nms      = "basin_reese" "basin_mask"
+    regions_load    = True 
+    regions_path    = "ice_data/{domain}/{grid_name}/{grid_name}_REGIONS.nc"
+    regions_nms     = "mask" "None"
+/
+
+&yelmo_init_topo
+    init_topo_load    = True 
+    init_topo_path    = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO-BedMachine.nc"
+    init_topo_names   = "H_ice" "z_bed" "z_bed_sd" "z_srf"      ! Ice thickness, bedrock elevation, bedrock noise, surface elevation
+    init_topo_state   = 0                                       ! 0: from file, 1: ice-free, 2: ice-free, rebounded 
+    z_bed_f_sd        = 0.0                                     ! Scaling fraction to modify z_bed = z_bed + f_sd*z_bed_sd
+    smooth_H_ice      = 0.0                                     ! Smooth ice thickness field at loading time, with sigma=N*dx
+    smooth_z_bed      = 0.0                                     ! Smooth bedrock field at loading time, with sigma=N*dx
+    
+/
+
+&yelmo_data 
+    pd_topo_load      = True 
+    pd_topo_path      = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO-BedMachine.nc"
+    pd_topo_names     = "H_ice" "z_bed" "z_bed_sd" "z_srf" "mask" ! Ice thickness, bedrock elevation, bedrock noise, surface elevation
+    pd_tsrf_load      = True 
+    pd_tsrf_path      = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_RACMO23-VW23.nc"
+    pd_tsrf_name      = "T_srf"                      ! Surface temperature (or near-surface temperature)
+    pd_tsrf_monthly   = True
+    pd_smb_load       = True 
+    pd_smb_path       = "ice_data/{domain}/{grid_name}/RACMO2.3/{grid_name}_RACMO23-VW23.nc"
+    pd_smb_name       = "smb"                        ! Surface mass balance 
+    pd_smb_monthly    = True 
+    pd_vel_load       = True 
+    pd_vel_path       = "ice_data/{domain}/{grid_name}/{grid_name}_VEL-R11-2.nc"
+    pd_vel_names      = "ux_srf" "uy_srf"            ! Surface velocity 
+    pd_age_load       = False 
+    pd_age_path       = "input/{domain}/{grid_name}/{grid_name}_STRAT-M15.nc"
+    pd_age_names      = "age_iso" "depth_iso"        ! ages of isochrones; depth of isochrones 
+
+/
+
+! ===== EXTERNAL LIBRARIES =====
+
+&smbpal
+    const_insol = True
+    const_kabp  = 0.0
+    insol_fldr  = "input"
+    abl_method  = "pdd" !"itm"   ! "itm" or "pdd"
+    sigma_snow  = 5.0     ! Standard deviation of temperature [K] over ice and snow
+    sigma_melt  = 5.0     ! Standard deviation of temperature [K] in ablation zone
+    sigma_land  = 5.0     ! Standard deviation of temperature [K] over land 
+    
+    sf_a        = 0.273   ! Snow fraction function (parameter a)
+    sf_b        = 273.6   ! Snow fraction function (parameter b)
+    firn_fac    = 0.0266  ! Reduction in surface temp versus melting [K/mm w.e.]
+
+    mm_snow = 3.0         ! PDD snow melt factor [mm w.e./K-d]
+    mm_ice  = 8.0         ! PDD ice melt factor  [mm w.e./K-d]
+    
+/
+
+&itm
+        
+    H_snow_max      =  5.0e3         ! Maximum allowed snowpack thickness [mm w.e.]
+    Pmaxfrac        =  0.6           ! Refreezing factor 
+
+    ! ## ITM 
+    trans_a         =  0.46 
+    trans_b         =  6e-5
+    trans_c         =  0.01
+    itm_c           = -55.0
+    itm_t           =  10.0
+    itm_b           =  3.0 
+    itm_lat0        =  -60.0 
+
+    ! ## Surface albedo
+    alb_snow_dry       =  0.8
+    alb_snow_wet       =  0.65
+    alb_ice            =  0.70
+    alb_land           =  0.2
+    alb_forest         =  0.1
+    alb_ocean          =  0.1
+    H_snow_crit_desert =  10.0
+    H_snow_crit_forest = 100.0
+    melt_crit          =   0.5      ! Critical melt rate to reduce snow albedo [mm/day]
+
+/
+
+&marine_shelf
+    bmb_method      = "quad-nl"        ! "pico", "anom", "lin", "quad", "quad-nl", "*-slope"
+    tf_method       = 1             ! 0: tf defined externally, 1: calculate as T_shlf-t_fp_shlf, 2: use dT_shlf
+    interp_depth    = "shlf"        ! "shlf", "bed", "const"
+    interp_method   = "interp"      ! "mean", "layer", "interp" ! Same method is used for salinity
+    find_ocean      = True          ! Find which points are connected to open ocean (ie, ignore subglacial lakes)
+    restart         = "none"        ! Load fields from a restart file?
+    
+    corr_method     = "bmb"          ! "tf": corrected tf basin, "bmb": corrected bmb basin, "tf-ant": use values in tf_corr_ant parameter section
+    basin_number    = 12
+    basin_bmb_corr  = 0.0           ! -1.0  -1.0 -1.0 [corrected bmb m/yr; -: melting, +: accretion]
+    basin_tf_corr   = 0.5 -0.17 -0.31 -0.24 0.31 0.25 -0.15 -0.1 -0.74 -0.62 -0.1 -2.5 -2.6 -1.67 0.0 -1.37 0.0 0.75 0.71
+    tf_correction   = False
+    tf_path         = "ice_data/ISMIP6/{domain}/{grid_name}/Ocean/{grid_name}_OCEAN_ISMIP6_J20.nc"
+    tf_name         = "dT_nl"
+ 
+    bmb_max         = 0.0           ! [m/a] Maximum allowed bmb value (eg, for no refreezing, set bmb_max=0.0) 
+    
+    ! Deep ocean bmb 
+    c_deep          = -10.0         ! [m/yr] Melt rate in deep ocean, should be negative but not huge
+    depth_deep      = 2000.0        ! [m] Depth at which deep ocean is assumed
+    depth_const     = 1000.0        ! [m] Constant shelf depth for interp_depth=const
+    depth_min       = 1100.0        ! [m] interp_method=mean, min depth to include
+    depth_max       = 1500.0        ! [m] interp_method=mean, max depth to include
+    
+    ! Freezing point coefficients
+    lambda1         = -0.0575       ! [degC PSU−1] Liquidus slope
+    lambda2         = 0.0832        ! [degC] Liquidus intercept 
+    lambda3         = 7.59e-4       ! [degC m−1] Liquidus pressure coefficient
+
+    ! bmb_method == [lin,quad,quad-nl] 
+    gamma_lin       = 630.0         ! [m/yr] Linear heat excange velocity. Favier et al., (2019) suggest 630.
+    gamma_quad      = 14.5e3       ! [m/yr] Quadratic heat exchange velocity. Jourdain et al. (2020) suggest 11100.
+    gamma_quad_nl   = 14.5e3        ! [m/yr] Quadratic non-local heat exchange velocity. Jourdain et al. (2020) suggest 14500.
+    gamma_prime     = 100.0         ! [-] Scalar when '*-slope' method is used
+
+    ! bmb_method == anom
+    kappa_grz       = 10.0          ! [m/yr K-1] Heat flux coefficient [kappa*dT]
+    c_grz           = 1.0           ! [-] bmb_ref scalar [c_grz*bmb_ref]
+    f_grz_shlf      = 10.0          ! [-] Ratio of grz melt to shelf melt
+    grz_length      = 32.0          ! [km] Length scale of assumed grounding zone
+
+    ! bmb_method == anom, bmb_ref parameters 
+    use_obs         = False         ! Load obs for bmb_ref
+    obs_path        = "ice_data/{domain}/{grid_name}/{grid_name}_BMELT-R13.nc"
+    obs_name        = "bm_eq_reese"
+    obs_scale       = 1.0           ! [-] bmb_ref = obs_scale*bmb_obs
+    obs_lim         = 100.0         ! [m/yr] Maximum magnitude of bmb_ref
+    basin_name      = "none"        !"northwest" "northeast" "east"
+    basin_bmb       = 0.0           !        -1.0       -1.0   -1.0
+    
+/
+
+&tf_corr_ant
+    ronne   = 0.0                   ! [K] tf_corr for ronne basin (basin=1)
+    ross    = 0.0                   ! [K] tf_corr for ross basin (basin=12)
+    pine    = 0.0                   ! [K] tf_corr for pine island (basin=14)
+    abbott  = 0.0                   ! [K] tf_corr for Abbott glacier (basin=15)
+/
+
+
+&pico
+    n_box          = 5.0        ! Maximum number of boxes in PICO.  
+    a_pico         = -0.0572    ! Salinity coefficient of freezing equation [ºC/PSU]. Reese et al., (2018) suggest −0.0572.
+    b_pico         = 0.0788     ! Constant coefficient of freezing equation [ºC]. Reese et al., (2018) suggest 0.0788.
+    c_pico         = 7.77e-8    ! Pressure coefficient of freezing equation [ºC/Pa]. Reese et al., (2018) suggest 7.77e-8.
+    alpha_pico     = 7.5e-5     ! Thermal expansion coefficien [1/ºC]. Reese et al., (2018) suggest 7.5e-5.
+    beta_pico      = 7.7e-4     ! Salt contraction coefficient [1/PSU]. Reese et al., (2018) suggest 7.7e-4.
+    rho_star       = 1033.0     ! Reference density [kg/m3]. Reese et al., (2018) suggest 1033.0.
+    gamma_tstar    = 630.0      ! Effective turbulent temperature exchange velocity [m/yr]. Reese et al., (2018) uses 630.0 and suggest 600-1000.
+    C_over         = 1.0        ! Overturning strength [Sv m3/kg]. Reese et al., (2018) suggest 1.0.
+
+/
+
+&sediments
+    use_obs   = False
+    obs_path  = "ice_data/{domain}/{grid_name}/{grid_name}_SED-L97.nc"
+    obs_name  = "z_sed"
+
+/
+
+&geothermal
+    use_obs   = True 
+    obs_path  = "ice_data/{domain}/{grid_name}/{grid_name}_GHF-HR24.nc"
+    obs_name  = "ghf"
+    ghf_const = 50.0           ! [mW/m^2]
+
+/
+
+&isos
+    ! Options
+    heterogeneous_ssh = .true.      ! Sea level varies spatially?
+    interactive_sealevel = .true.   ! Sea level interacts with solid Earth deformation?
+    include_elastic = .true.        ! Include elastic deformation?
+    correct_compression = .true.    ! Account for compression effects on relaxation time?
+    correct_distortion = .false.    ! Account for distortion of projection?
+    method          = 2             ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
+    dt_prognostics  = 1.0           ! [yr] Max. timestep to recalculate prognostics
+    dt_diagnostics  = 10.           ! [yr] Min. timestep to recalculate diagnostics
+    pad         = 1024.             ! [km] Padding around the domain (preferably chosen as a power
+                                    ! of 2 multiplied by the resolution)
+
+
+    ! Rheology methods
+    mantle = "rheology_file"        ! Choose mantle viscosity field, options:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "rheology_file"   ! Choose lithospheric thickness field:
+                                    ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "parallel"        ! "parallel" or "equalized"
+    lumping     = "min"             ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "none"  ! "scale" or "min" or "max"
+    viscosity_scaling = 1.              ! Only used if viscosity_scaling_method = "scale"
+    
+    ! Rheology parameters
+    nl          = 5             ! [1] Number of viscous layers for sub-lithospheric mantle
+    dl          = 25.               ! [km] Thickness of viscous layers. Only used if layering="parallel".
+    zl          = 100, 150, 200, 250, 300     ! [km] Depth of layer boundaries.
+                                    ! Only used if layering="equalized". First value 
+                                    ! overwritten if visc_method="rheology_file".
+    viscosities = 1e21, 1e21, 1e21, 1e21, 2e21     ! [Pa s] Layer viscosities. Only used if
+                                    ! mantle = "uniform" or "gaussian_plus" or "gaussian_minus".
+                                    ! viscosity field is provided.
+    ref_viscosity = 1.e21       ! [Pa s] Reference viscosity for scaling
+    tau = 3000.0                ! [yr] Relaxation time used for "method" = 2
+    rheo_smoothing_radius = 40.0! [km] Gaussian moothing radius for lithospheric thickness
+                                ! and mantle viscosity
+
+    ! Physical constants
+    E               = 66.0          ! [GPa] Young modulus
+    nu              = 0.28          ! [-] Poisson ratio
+    rho_ice         = 910.          ! [kg/m^3]
+    rho_seawater    = 1028.0        ! [kg/m^3]
+    rho_water       = 1000.0        ! [kg/m^3]
+    rho_uppermantle = 3400.0        ! [kg/m^3]
+    rho_litho       = 3200.0        ! [kg/m^3]  Optionally set to 0 ==> decouple the elastic
+                                    ! displacement from the viscous one
+    g               = 9.81          ! [m/s^2]
+    r_earth         = 6.378e3       ! [km] Earth radius, Coulon et al. (2021)
+    m_earth         = 5.972e24      ! [kg] Earth mass,   Coulon et al. (2021)
+
+    ! Files
+    restart = "None"
+    mask_file = "None"
+    rheology_file = "isostasy_data/earth_structure/yelmo/ANT-16KM_GIA_HR24.nc"
+    litho_thickness_varname = "litho_thickness" ! Variable name in netcdf file
+    log10_viscosity_varname = "log10_visc"       ! Variable name in netcdf file
+    stddev_log10_viscosity_varname = "stddev_log10_visc"     ! Variable name in netcdf file
+
+/
+
+&barysealevel
+    method      = "fastiso" ! "const": BSL = bsl_init throughout sim
+                            ! "file": BSL = time series provided from sl_path
+                            ! "fastiso": BSL = sum of contributions from fastiso domains
+    bsl_init    = 0.0       ! [m] BSL relative to present day
+    sl_path     = "none"    ! Input time series filename
+    sl_name     = "none"    ! Variable name in netcdf file, if relevant
+    A_ocean_pd  = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
+    A_ocean_path = "isostasy_data/tools/ocean_surface/OceanSurfaceETOPO2022.nc"
+    restart    = "None"
+/
+

--- a/par/yelmo_Antarctica_nudge.nml
+++ b/par/yelmo_Antarctica_nudge.nml
@@ -252,7 +252,8 @@
     beta_min            = 100            ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 4               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_Antarctica_rtip.nml
+++ b/par/yelmo_Antarctica_rtip.nml
@@ -252,7 +252,8 @@
  scale_T         = 1
 T_frz            = -3.0     
  ssa_lis_opt     = '-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false'
- ssa_lat_bc      = 'floating' 
+ ssa_solver      = 'energy'        ! 'residual' | 'energy'
+ ssa_lat_bc      = 'all'      
  ssa_beta_max    = 1e+20      
  ssa_vel_max     = 5000.0     
  ssa_iter_max    = 4          

--- a/par/yelmo_Greenland.nml
+++ b/par/yelmo_Greenland.nml
@@ -193,7 +193,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_Greenland_rembo.nml
+++ b/par/yelmo_Greenland_rembo.nml
@@ -214,7 +214,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_LIS.nml
+++ b/par/yelmo_LIS.nml
@@ -162,7 +162,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-1 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution (20)

--- a/par/yelmo_North.nml
+++ b/par/yelmo_North.nml
@@ -162,7 +162,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-1 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution (20)

--- a/par/yelmo_Pyrenees.nml
+++ b/par/yelmo_Pyrenees.nml
@@ -186,7 +186,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_bipolar.nml
+++ b/par/yelmo_bipolar.nml
@@ -213,7 +213,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = '-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false'  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = 'floating'      ! 'all', 'marine', 'floating', 'none', 'slab'
+    ssa_solver          = 'energy'        ! 'residual' | 'energy'
+    ssa_lat_bc          = 'all'           ! 'all', 'marine', 'floating', 'none', 'slab'
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_ismip6_Antarctica.nml
+++ b/par/yelmo_ismip6_Antarctica.nml
@@ -229,7 +229,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 4               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_nahosmip_Antarctica.nml
+++ b/par/yelmo_nahosmip_Antarctica.nml
@@ -229,7 +229,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 4               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_pd_Antarctica.nml
+++ b/par/yelmo_pd_Antarctica.nml
@@ -197,7 +197,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/par/yelmo_pd_Greenland.nml
+++ b/par/yelmo_pd_Greenland.nml
@@ -230,7 +230,8 @@
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
     ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
     ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution

--- a/yelmox_esm.f90
+++ b/yelmox_esm.f90
@@ -269,25 +269,15 @@ program yelmox_esm
     call bsl_init(bsl, path_par, ts%time_rel)
 
     ! Initialize fastisosaty
-    call isos_init(isos1, path_par, "isos", yelmo1%grd%nx, yelmo1%grd%ny, &
-        yelmo1%grd%dx, yelmo1%grd%dy)
+    call isos_init(isos1, path_par, "isos", yelmo1%grd%nx, yelmo1%grd%ny, yelmo1%grd%dx, yelmo1%grd%dy)
     
     ! Initialize ESM atmospheric and oceanic objects 
     esm_path_par = trim(outfldr)//"/"//trim(ctl%esm_par_file)
-    if(ctl%esm_use_esm) then
-        ! we are using a gcm output
-        call esm_forcing_init(esm1,esm_path_par,domain,grid_name,gcm=ctl%esm_name,scenario=ctl%esm_experiment)
-    else
-        ! ctrl experiment
-        call esm_forcing_init(esm1,esm_path_par,domain,grid_name,experiment=ctl%esm_experiment)
-        ! jablasco
-        !if(trim(grid_name) .ne. trim(grid_src))
-        !    call esm_src_init(esm1,esm_path_par,domain,grid_src,experiment=ctl%esm_experiment)    
-    end if
+    call esm_forcing_init(esm1,esm_path_par,domain,grid_name,gcm=ctl%esm_name,scenario=ctl%esm_experiment,use_esm=ctl%esm_use_esm)
 
     ! Initialize surface mass balance model (bnd%smb, bnd%T_srf)
     call smbpal_init(smbpal1,path_par,x=yelmo1%grd%xc,y=yelmo1%grd%yc,lats=yelmo1%grd%lat)
-    
+
     ! Initialize marine melt model (bnd%bmb_shlf)
     call marshelf_init(mshlf1,path_par,"marine_shelf",yelmo1%grd%nx,yelmo1%grd%ny,domain,grid_name,yelmo1%bnd%regions,yelmo1%bnd%basins)
     
@@ -447,7 +437,7 @@ program yelmox_esm
                                                     yelmo1%tpo%now%dHidt,yelmo1%bnd%z_bed,yelmo1%bnd%z_sl,yelmo1%dyn%now%ux_s,yelmo1%dyn%now%uy_s, &
                                                     yelmo1%dta%pd%H_ice,yelmo1%dta%pd%uxy_s,yelmo1%dta%pd%H_grnd, &
                                                     opt%cf_min,opt%cf_max,yelmo1%tpo%par%dx,opt%sigma_err,opt%sigma_vel,opt%tau_c,opt%H0, &
-                                                    dt=ctl%dtt,fill_method=opt%fill_method,fill_dist=opt%sigma_err)
+                                                    dt=ctl%dtt,fill_method=opt%fill_method,fill_dist=opt%sigma_err,cb_tgt=yelmo1%dyn%now%cb_tgt)
                         
                     end if
 
@@ -572,10 +562,6 @@ program yelmox_esm
         write(*,*)
         write(*,*) "Performing transient."
         write(*,*) 
-
-        ! Additionally make sure isostasy is updated every timestep 
-        isos1%par%dt_prognostics = 1.0_wp 
-        isos1%par%dt_diagnostics = 10.0_wp 
 
         ! Initialize output files 
         call yelmo_write_init(yelmo1,file2D,time_init=ts%time,units="years")
@@ -722,30 +708,24 @@ contains
                                     ylmo%tpo%now%H_ice,ylmo%bnd%basins,ylmo%bnd%z_bed,ylmo%tpo%now%f_grnd,ylmo%bnd%z_sl, &
                                     use_ref_atm=.false.,use_ref_ocn=.false.)
         
+        ! Check anomalies
         if (.FALSE.) then
-            ! Anomaly check
+            ! ATM Anomaly check
             write(*,*) "dts = ",     maxval(esm%dts)
-            write(*,*) "dto = ",     maxval(esm%dto)
             write(*,*) "dts_var = ", maxval(esm%dts_var)
+            write(*,*) "dpr = ",     maxval(esm%dpr)
+            write(*,*) "dpr_var = ", maxval(esm%dpr_var)
+            ! OCN Anomaly check
+            write(*,*) "dto = ",     maxval(esm%dto)
             write(*,*) "dto_var = ", maxval(esm%dto_var)
+            write(*,*) "dso = ",     maxval(esm%dso)
+            write(*,*) "dso_var = ", maxval(esm%dso_var)
         end if
     
         ! === Atmospheric boundary conditions ===
-        ! Calculate the smb fields
-        if (.FALSE.) then
-                esm%dts_var = -esm%dts_var
-                esm%dpr_var = 1/esm%dpr_var
-        end if
+        ! Calculate SMB fields
         call smbpal_update_monthly(smbp,esm%t2m+esm%dts+esm%dts_var,esm%pr*esm%dpr*esm%dpr_var, &
                                     ylmo%tpo%now%z_srf,ylmo%tpo%now%H_ice,time)
-    
-        if (.FALSE.) then
-            ! Atm check
-            write(*,*) "Ts_ref_max = ",maxval(esm%ts_ref%var(:,:,:,1))
-            write(*,*) "Pr_ref_max = ",maxval(esm%pr_ref%var(:,:,:,1))
-            write(*,*) "Ts_ref_min = ",minval(esm%ts_ref%var(:,:,:,1))
-            write(*,*) "Pr_ref_min = ",minval(esm%pr_ref%var(:,:,:,1))
-        end if
     
         ! === Oceanic boundary conditions ===
         ! Interpolate ocean data to the interior of the ice shelf
@@ -753,6 +733,11 @@ contains
         call ocn_variable_extrapolation(esm%so_ref%var(:,:,:,1), ylmo%tpo%now%H_ice, ylmo%bnd%basins,-esm%so_ref%z,ylmo%bnd%z_bed)
     
         if (.FALSE.) then
+            ! Atm check
+            write(*,*) "Ts_ref_max = ",maxval(esm%ts_ref%var(:,:,:,1))
+            write(*,*) "Pr_ref_max = ",maxval(esm%pr_ref%var(:,:,:,1))
+            write(*,*) "Ts_ref_min = ",minval(esm%ts_ref%var(:,:,:,1))
+            write(*,*) "Pr_ref_min = ",minval(esm%pr_ref%var(:,:,:,1))
             ! Ocean check
             write(*,*) "To_max = ",maxval(esm%to_ref%var(:,:,:,1))
             write(*,*) "So_max = ",maxval(esm%so_ref%var(:,:,:,1))
@@ -766,12 +751,7 @@ contains
         call marshelf_interp_shelf(mshlf%now%S_shlf,mshlf,esm%so_ref%var(:,:,:,1),ylmo%tpo%now%H_ice, &
                                         ylmo%bnd%z_bed,ylmo%tpo%now%f_grnd,ylmo%bnd%z_sl,-esm%so_ref%z)
     
-        ! Add the anomaly from 
-        ! jablasco: opt test
-        if (.FALSE.) then
-                esm%dto_var = -esm%dto_var
-                esm%dso_var = -esm%dso_var
-        end if
+        ! Add anomaly to reference ocean
         mshlf%now%T_shlf = mshlf%now%T_shlf + esm%dto + esm%dto_var
         mshlf%now%S_shlf = mshlf%now%S_shlf + esm%dso + esm%dso_var
     
@@ -1231,10 +1211,14 @@ contains
         call nc_write(filename,"tf_corr",mshlf%now%tf_corr,units="K",long_name="Shelf thermal forcing correction factor", &
                         dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
         if (.FALSE.) then
-        call nc_write(filename,"so_ref",esm%so_ref%var(:,:,1,1),units="PSU",long_name="Reference oceanic salinity", &
-                        dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
-        call nc_write(filename,"to_ref",esm%to_ref%var(:,:,1,1),units="K",long_name="Reference oceanic temperature", &
-                        dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)        
+            call nc_write(filename,"so_ref",esm%so_ref%var(:,:,1,1),units="PSU",long_name="Reference oceanic salinity", &
+                            dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+            call nc_write(filename,"to_ref",esm%to_ref%var(:,:,1,1),units="K",long_name="Reference oceanic temperature", &
+                            dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)    
+            call nc_write(filename,"smb",ylmo%tpo%now%smb,units="m/a ice equiv.",long_name="Net surface mass balance", &
+                            dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
+            call nc_write(filename,"smb_ref",ylmo%bnd%smb,units="m/a ice equiv.",long_name="Surface mass balance", &
+                            dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)    
         end if
 
         ! Close the netcdf file


### PR DESCRIPTION
## Summary
- Add missing `ydyn.ssa_solver = "energy"` parameter to all yelmo `par/*.nml` files
- Flip `ydyn.ssa_lat_bc` from `"floating"` to `"all"` across all par files

## Files touched
14 files: yelmo_Antarctica.nml, yelmo_Antarctica_esm.nml, yelmo_Antarctica_nudge.nml, yelmo_Antarctica_rtip.nml, yelmo_Greenland.nml, yelmo_Greenland_rembo.nml, yelmo_LIS.nml, yelmo_North.nml, yelmo_Pyrenees.nml, yelmo_bipolar.nml, yelmo_ismip6_Antarctica.nml, yelmo_nahosmip_Antarctica.nml, yelmo_pd_Antarctica.nml, yelmo_pd_Greenland.nml.