### PR TITLE
Replace bnd%ice_allowed with bnd%mask_ice across yelmox programs

### DIFF
--- a/yelmox.f90
+++ b/yelmox.f90
@@ -202,15 +202,15 @@ program yelmox
 
         case("Laurentide")
 
-            ! Make sure to set ice_allowed to prevent ice from growing in 
+            ! Make sure to set mask_ice to prevent ice from growing in
             ! Greenland (and on grid borders)
 
-            where(abs(yelmo1%bnd%regions - 1.30) .lt. 1e-3) yelmo1%bnd%ice_allowed = .FALSE. 
-            
-            yelmo1%bnd%ice_allowed(1,:)             = .FALSE. 
-            yelmo1%bnd%ice_allowed(yelmo1%grd%nx,:) = .FALSE. 
-            yelmo1%bnd%ice_allowed(:,1)             = .FALSE. 
-            yelmo1%bnd%ice_allowed(:,yelmo1%grd%ny) = .FALSE. 
+            where(abs(yelmo1%bnd%regions - 1.30) .lt. 1e-3) yelmo1%bnd%mask_ice = -1
+
+            yelmo1%bnd%mask_ice(1,:)             = -1
+            yelmo1%bnd%mask_ice(yelmo1%grd%nx,:) = -1
+            yelmo1%bnd%mask_ice(:,1)             = -1
+            yelmo1%bnd%mask_ice(:,yelmo1%grd%ny) = -1
             
             ! Initialize regions
             call yelmo_regions_init(yelmo1,n=1)
@@ -247,12 +247,12 @@ if (.FALSE.) then
             end if 
 end if
 
-            ! Make sure to set ice_allowed to prevent ice from growing in 
+            ! Make sure to set mask_ice to prevent ice from growing in
             ! Iceland and Svaalbard (on grid borders)
 
-            where(abs(yelmo1%bnd%regions - 1.20) .lt. 1e-3) yelmo1%bnd%ice_allowed = .FALSE. 
-            where(abs(yelmo1%bnd%regions - 1.23) .lt. 1e-3) yelmo1%bnd%ice_allowed = .FALSE. 
-            where(abs(yelmo1%bnd%regions - 1.31) .lt. 1e-3) yelmo1%bnd%ice_allowed = .FALSE.            
+            where(abs(yelmo1%bnd%regions - 1.20) .lt. 1e-3) yelmo1%bnd%mask_ice = -1
+            where(abs(yelmo1%bnd%regions - 1.23) .lt. 1e-3) yelmo1%bnd%mask_ice = -1
+            where(abs(yelmo1%bnd%regions - 1.31) .lt. 1e-3) yelmo1%bnd%mask_ice = -1
             
             if (yelmo1%dyn%par%till_method .eq. -1) then 
                 ! Initialize cb_ref to constant value to start
@@ -399,7 +399,7 @@ end if
                 ! Add extra ice-thickness over continental shelf to start with
                 ! an LGM-like state
 
-                where(yelmo1%bnd%ice_allowed .and. yelmo1%tpo%now%H_ice .lt. 600.0 &
+                where(yelmo1%bnd%mask_ice /= -1 .and. yelmo1%tpo%now%H_ice .lt. 600.0 &
                         .and. yelmo1%bnd%z_bed .gt. -500.0)
 
                         yelmo1%tpo%now%H_ice = 800.0 

--- a/yelmox_bipolar.f90
+++ b/yelmox_bipolar.f90
@@ -1334,15 +1334,15 @@ contains
 
                 end if 
 
-                ! Make sure to set ice_allowed to prevent ice from growing in 
+                ! Make sure to set mask_ice to prevent ice from growing in
                 ! Greenland (and on grid borders)
 
-                where(abs(yelmox%yelmo1%bnd%regions - 1.30) .lt. 1e-3) yelmox%yelmo1%bnd%ice_allowed = .FALSE. 
-                
-                yelmox%yelmo1%bnd%ice_allowed(1,:)             = .FALSE. 
-                yelmox%yelmo1%bnd%ice_allowed(yelmox%yelmo1%grd%nx,:) = .FALSE. 
-                yelmox%yelmo1%bnd%ice_allowed(:,1)             = .FALSE. 
-                yelmox%yelmo1%bnd%ice_allowed(:,yelmox%yelmo1%grd%ny) = .FALSE. 
+                where(abs(yelmox%yelmo1%bnd%regions - 1.30) .lt. 1e-3) yelmox%yelmo1%bnd%mask_ice = -1
+
+                yelmox%yelmo1%bnd%mask_ice(1,:)                       = -1
+                yelmox%yelmo1%bnd%mask_ice(yelmox%yelmo1%grd%nx,:)    = -1
+                yelmox%yelmo1%bnd%mask_ice(:,1)                       = -1
+                yelmox%yelmo1%bnd%mask_ice(:,yelmox%yelmo1%grd%ny)    = -1
                 
                 ! Initialize regions
                 call yelmo_regions_init(yelmox%yelmo1,n=1)
@@ -1375,12 +1375,12 @@ contains
                     
                 end if 
 
-                ! Make sure to set ice_allowed to prevent ice from growing in 
+                ! Make sure to set mask_ice to prevent ice from growing in
                 ! Iceland and Svaalbard (on grid borders)
 
-                where(abs(yelmox%yelmo1%bnd%regions - 1.20) .lt. 1e-3) yelmox%yelmo1%bnd%ice_allowed = .FALSE. 
-                where(abs(yelmox%yelmo1%bnd%regions - 1.23) .lt. 1e-3) yelmox%yelmo1%bnd%ice_allowed = .FALSE. 
-                where(abs(yelmox%yelmo1%bnd%regions - 1.31) .lt. 1e-3) yelmox%yelmo1%bnd%ice_allowed = .FALSE.            
+                where(abs(yelmox%yelmo1%bnd%regions - 1.20) .lt. 1e-3) yelmox%yelmo1%bnd%mask_ice = -1
+                where(abs(yelmox%yelmo1%bnd%regions - 1.23) .lt. 1e-3) yelmox%yelmo1%bnd%mask_ice = -1
+                where(abs(yelmox%yelmo1%bnd%regions - 1.31) .lt. 1e-3) yelmox%yelmo1%bnd%mask_ice = -1
                 
                 if (yelmox%yelmo1%dyn%par%till_method .eq. -1) then 
                     ! Initialize cb_ref to constant value to start
@@ -1603,7 +1603,7 @@ contains
                     ! Add extra ice-thickness over continental shelf to start with
                     ! an LGM-like state
 
-                    where(yelmox%yelmo1%bnd%ice_allowed .and. yelmox%yelmo1%tpo%now%H_ice .lt. 600.0 &
+                    where(yelmox%yelmo1%bnd%mask_ice /= -1 .and. yelmox%yelmo1%tpo%now%H_ice .lt. 600.0 &
                             .and. yelmox%yelmo1%bnd%z_bed .gt. -500.0)
 
                             yelmox%yelmo1%tpo%now%H_ice = 800.0 

--- a/yelmox_esm.f90
+++ b/yelmox_esm.f90
@@ -329,7 +329,7 @@ program yelmox_esm
 
     ! Set new boundary conditions: if desired kill ice shelves beyond present-day extent
     if (ctl%kill_shelves) then
-        where(yelmo1%dta%pd%mask_bed .eq. mask_bed_ocean) yelmo1%bnd%ice_allowed = .FALSE.
+        where(yelmo1%dta%pd%mask_bed .eq. mask_bed_ocean) yelmo1%bnd%mask_ice = -1
     end if
     
 ! ================= RUN STEPS ===============================================
@@ -567,12 +567,12 @@ program yelmox_esm
         call yelmo_write_init(yelmo1,file2D,time_init=ts%time,units="years")
         call yelmo_write_init(yelmo1,file2Dsm,time_init=ts%time,units="years")
         call yelmo_regions_write(yelmo1,ts%time,init=.TRUE.,units="years")
-        call yelmo_write_reg_init(yelmo1,file1D_esm,time_init=ts%time,units="years",mask=yelmo1%bnd%ice_allowed) 
+        call yelmo_write_reg_init(yelmo1,file1D_esm,time_init=ts%time,units="years",mask=(yelmo1%bnd%mask_ice /= -1))
 
         if (ctl%esm_write_formatted) then
             ! Initialize output files for esm
             call yelmo_write_init(yelmo1,file2D_esm,time_init=ts%time,units="years")
-            call yelmo_write_reg_init(yelmo1,file1D_esm,time_init=ts%time,units="years",mask=yelmo1%bnd%ice_allowed) 
+            call yelmo_write_reg_init(yelmo1,file1D_esm,time_init=ts%time,units="years",mask=(yelmo1%bnd%mask_ice /= -1))
         end if 
 
         call timer_step(tmr,comp=1,label="initialization") 
@@ -808,7 +808,7 @@ contains
         call nc_write(filename,"lsf",ylmo%tpo%now%lsf,units="",long_name="LSF mask", &
                     dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
 
-        call nc_write(filename,"ice_allowed",ylmo%bnd%ice_allowed,units="",long_name="Ice allowed mask", &
+        call nc_write(filename,"mask_ice",ylmo%bnd%mask_ice,units="",long_name="Ice mask", &
                     dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
 
         call nc_write(filename,"mask_frnt",ylmo%tpo%now%mask_frnt,units="",long_name="Ice-front mask", &

--- a/yelmox_ismip6.f90
+++ b/yelmox_ismip6.f90
@@ -559,7 +559,7 @@ program yelmox_ismip6
         if (ctl%ismip6_write_formatted) then
             ! Initialize output files for ISMIP6
             call yelmo_write_init(yelmo1,file2D_ismip6,time_init=ts%time,units="years")
-            call yelmo_write_reg_init(yelmo1,file1D_ismip6,time_init=ts%time,units="years",mask=yelmo1%bnd%ice_allowed) 
+            call yelmo_write_reg_init(yelmo1,file1D_ismip6,time_init=ts%time,units="years",mask=(yelmo1%bnd%mask_ice /= -1))
         end if 
 
         call timer_step(tmr,comp=1,label="initialization") 
@@ -582,7 +582,7 @@ program yelmox_ismip6
 
                 if(ts%time .ge. 2015) then
                     !where((yelmo1%tpo%now%f_grnd .eq. 0.0) .and. (ismp1%mask_shlf%var(:,:,1,1) .eq. 1.0)) yelmo1%tpo%now%H_ice = 0.0
-                    where((yelmo1%tpo%now%f_grnd .eq. 0.0) .and. (ismp1%mask_shlf%var(:,:,1,1) .eq. 1.0)) yelmo1%bnd%ice_allowed = .FALSE.
+                    where((yelmo1%tpo%now%f_grnd .eq. 0.0) .and. (ismp1%mask_shlf%var(:,:,1,1) .eq. 1.0)) yelmo1%bnd%mask_ice = -1
                 end if
             end if
 
@@ -713,7 +713,7 @@ contains
         call nc_write(filename,"mask_grz",ylmo%tpo%now%mask_grz,units="",long_name="Grounding-zone mask", &
                         dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
 
-        call nc_write(filename,"ice_allowed",ylmo%bnd%ice_allowed,units="",long_name="Ice allowed mask", &
+        call nc_write(filename,"mask_ice",ylmo%bnd%mask_ice,units="",long_name="Ice mask", &
                         dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
 
         !call nc_write(filename,"mask_frnt",ylmo%tpo%now%mask_frnt,units="",long_name="Ice-front mask", &

--- a/yelmox_nahosmip.f90
+++ b/yelmox_nahosmip.f90
@@ -529,7 +529,7 @@ program yelmox_ismip6
         if (ctl%ismip6_write_formatted) then
             ! Initialize output files for ISMIP6
             call yelmo_write_init(yelmo1,file2D_ismip6,time_init=ts%time,units="years")
-            call yelmo_write_reg_init(yelmo1,file1D_ismip6,time_init=ts%time,units="years",mask=yelmo1%bnd%ice_allowed) 
+            call yelmo_write_reg_init(yelmo1,file1D_ismip6,time_init=ts%time,units="years",mask=(yelmo1%bnd%mask_ice /= -1))
         end if 
 
         call timer_step(tmr,comp=1,label="initialization") 
@@ -658,7 +658,7 @@ contains
         call nc_write(filename,"mask_grz",ylmo%tpo%now%mask_grz,units="",long_name="Grounding-zone mask", &
                         dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
 
-        call nc_write(filename,"ice_allowed",ylmo%bnd%ice_allowed,units="",long_name="Ice allowed mask", &
+        call nc_write(filename,"mask_ice",ylmo%bnd%mask_ice,units="",long_name="Ice mask", &
                         dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
 
         !call nc_write(filename,"mask_frnt",ylmo%tpo%now%mask_frnt,units="",long_name="Ice-front mask", &

--- a/yelmox_rembo.f90
+++ b/yelmox_rembo.f90
@@ -293,7 +293,7 @@ program yelmox
         ! Increase ice thickness everywhere to start
         yelmo1%tpo%now%H_ice = yelmo1%tpo%now%H_ice*1.2
 
-        ! where(yelmo1%bnd%ice_allowed .and. yelmo1%tpo%now%H_ice .lt. 600.0 &
+        ! where(yelmo1%bnd%mask_ice /= -1 .and. yelmo1%tpo%now%H_ice .lt. 600.0 &
         !         .and. yelmo1%bnd%z_bed .gt. -500.0)
 
         !         yelmo1%tpo%now%H_ice = 800.0 
@@ -331,7 +331,7 @@ program yelmox
 
     ! Small 1D-2D yelmo-rembo file
     call yelmox_write_init(yelmo1,file_rembo,time_init=ts%time,units="years", &
-                    mask=yelmo1%bnd%ice_allowed,dT_min=hyst1%par%f_min,dT_max=hyst1%par%f_max)
+                    mask=(yelmo1%bnd%mask_ice /= -1),dT_min=hyst1%par%f_min,dT_max=hyst1%par%f_max)
 
     call timer_step(tmr,comp=1,label="initialization") 
     call timer_step(tmrs,comp=-1)
@@ -637,7 +637,7 @@ contains
                       dim1="time",start=[n],ncid=ncid)
         
         if (n .eq. 1) then
-            call nc_write(filename,"ice_allowed",ylmo%bnd%ice_allowed,units="",long_name="Ice allowed mask", &
+            call nc_write(filename,"mask_ice",ylmo%bnd%mask_ice,units="",long_name="Ice mask", &
                         dim1="xc",dim2="yc",start=[1,1],ncid=ncid)
             call nc_write(filename,"H_sed",ylmo%bnd%H_sed,units="m",long_name="Sediment thickness", &
                         dim1="xc",dim2="yc",start=[1,1],ncid=ncid)
@@ -757,7 +757,7 @@ contains
         call yelmo_write_step_pd_metrics(filename,ylmo,n,ncid)
         
         if (n .eq. 1) then
-            call nc_write(filename,"ice_allowed",ylmo%bnd%ice_allowed,units="",long_name="Ice allowed mask", &
+            call nc_write(filename,"mask_ice",ylmo%bnd%mask_ice,units="",long_name="Ice mask", &
                         dim1="xc",dim2="yc",start=[1,1],ncid=ncid)
             call nc_write(filename,"H_sed",ylmo%bnd%H_sed,units="m",long_name="Sediment thickness", &
                         dim1="xc",dim2="yc",start=[1,1],ncid=ncid)

--- a/yelmox_rtip.f90
+++ b/yelmox_rtip.f90
@@ -363,7 +363,7 @@ program yelmox_rtip
 
     ! Set new boundary conditions: if desired kill ice shelves beyond present-day extent
     if (ctl%kill_shelves) then
-        where(yelmo1%dta%pd%mask_bed .eq. mask_bed_ocean) yelmo1%bnd%ice_allowed = .FALSE.
+        where(yelmo1%dta%pd%mask_bed .eq. mask_bed_ocean) yelmo1%bnd%mask_ice = -1
     end if
 
 ! ================= RUN STEPS ===============================================
@@ -621,7 +621,7 @@ program yelmox_rtip
         if (ctl%ismip6_write_formatted) then
             ! Initialize output files for ISMIP6
             call yelmo_write_init(yelmo1,file2D_ismip6,time_init=ts%time,units="years")
-            call yelmo_write_reg_init(yelmo1,file1D_ismip6,time_init=ts%time,units="years",mask=yelmo1%bnd%ice_allowed)
+            call yelmo_write_reg_init(yelmo1,file1D_ismip6,time_init=ts%time,units="years",mask=(yelmo1%bnd%mask_ice /= -1))
         end if
 
         call timer_step(tmr,comp=1,label="initialization")
@@ -644,7 +644,7 @@ program yelmox_rtip
 
                 if(ts%time .ge. 2015) then
                     !where((yelmo1%tpo%now%f_grnd .eq. 0.0) .and. (ismp1%mask_shlf%var(:,:,1,1) .eq. 1.0)) yelmo1%tpo%now%H_ice = 0.0
-                    where((yelmo1%tpo%now%f_grnd .eq. 0.0) .and. (ismp1%mask_shlf%var(:,:,1,1) .eq. 1.0)) yelmo1%bnd%ice_allowed = .FALSE.
+                    where((yelmo1%tpo%now%f_grnd .eq. 0.0) .and. (ismp1%mask_shlf%var(:,:,1,1) .eq. 1.0)) yelmo1%bnd%mask_ice = -1
                 end if
             end if
 
@@ -768,7 +768,7 @@ program yelmox_rtip
         ! Initialize hysteresis output files
         ! call yelmo_write_init(yelmo1, file1D, time_init=time, units="years")
         call yelmo_write_reg_init(yelmo1, file1D, time_init=time, units="years", &
-            mask=yelmo1%bnd%ice_allowed)
+            mask=(yelmo1%bnd%mask_ice /= -1))
         call yelmo_write_init(yelmo1, file2D, time_init=time, units="years")
         call yelmo_write_init(yelmo1, file2D_wais, time, "years", &
             irange=[i1wais, i2wais], jrange=[j1wais, j2wais])


### PR DESCRIPTION
## Summary

Yelmo main removed the boolean `bnd%ice_allowed` field in favor of the integer `bnd%mask_ice` (-1: ice forbidden, 0: ice prescribed, 1: ice calculated). This PR updates all yelmox driver programs accordingly so they compile against the current yelmo:main.

Conversions applied:
- assignments: `bnd%ice_allowed = .FALSE.` → `bnd%mask_ice = -1`
- boolean masks (`where(...)`, `mask=` args): `bnd%ice_allowed` → `(bnd%mask_ice /= -1)`
- `nc_write` outputs: rename variable `"ice_allowed"` → `"mask_ice"` and write the integer field directly (carries the full -1/0/1 information).

Files touched: `yelmox.f90`, `yelmox_bipolar.f90`, `yelmox_esm.f90`, `yelmox_ismip6.f90`, `yelmox_nahosmip.f90`, `yelmox_rembo.f90`, `yelmox_rtip.f90`. `yelmox_unused/` was intentionally left alone.

## Test plan

- [x] `make yelmox` builds
- [x] `make yelmox_ismip6` builds
- [x] `make yelmox_esm` builds
- [x] `make yelmox_nahosmip` builds
- [x] `make yelmox_rembo` builds
- [x] `make yelmox_bipolar` builds
- [ ] `make yelmox_rtip` — fails on a *pre-existing* missing `coordinates_mapping_scrip.mod` issue at line 1094 (reproducible on `main` once the `ice_allowed` errors are bypassed). The `ice_allowed` → `mask_ice` edits themselves compile through that file cleanly.