### PR TITLE
Sync yelmo par files with current yelmo namelist schema

### DIFF
--- a/par/PMYY_MAG_Bipolar/OBM_hyster_forcby_ISM/yelmo_bipolar.nml
+++ b/par/PMYY_MAG_Bipolar/OBM_hyster_forcby_ISM/yelmo_bipolar.nml
@@ -113,54 +113,63 @@
 
 &ytopo
     solver              = "impl-lis"        ! "expl", "impl-lis"
-    calv_flt_method     = "vm-l19"          ! "zero", "simple", "flux", "vm-l19", "kill"
-    calv_grnd_method    = "stress-b12"      ! "zero", "stress-b12"
-    bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
-    fmb_method          = 1                 ! 0: prescribe boundary field fmb_shlf; 1: calculate proportional fmb~bmb_shlf.
-    dmb_method          = 0                 ! 0: no subgrid discharge, 1: subgrid discharge on
     surf_gl_method      = 0                 ! 0: binary (max grnd/flt elevation), 1: subgrid average elevation
-    margin_flt_subgrid  = True              ! Allow fractional ice area for floating margins
-    margin2nd           = False             ! Apply second-order upwind approximation to gradients at the margin
-    use_bmb             = True              ! Use basal mass balance in mass conservation equation
-    topo_fixed          = False             ! Keep ice thickness fixed, perform other ytopo calculations
-    topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
-    topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
-    topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    calv_tau            = 1.0               ! [a] Characteristic calving time
-    calv_thin           = 30.0              ! [m/yr] Calving rate to apply to very thin ice
-    H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated) - helps with stability
-    H_min_flt           = 0.0               ! [m] Minimum ice thickness at floating margin (thinner ice is ablated) - helps with stability
-    sd_min              = 100.0             ! [m] calv_grnd(z_bed_sd <  = sd_min)     = 0.0 
-    sd_max              = 500.0             ! [m] calv_grnd(z_bed_sd >  = sd_max)     = calv_max  
-    calv_grnd_max       = 0.0               ! [m/a] Maximum grounded calving rate from high stdev(z_bed)
     grad_lim            = 0.1               ! [m/m] Maximum allowed sloped in gradient calculations (dz/dx,dH/dx)
     grad_lim_zb         = 0.05              ! [m/m] Maximum allowed sloped in bed gradient (dzb/dx)
-    dist_grz            = 200.0             ! [km] Radius to consider part of "grounding-line zone" (grz)
+    dHdt_dyn_lim        = 100.0             ! [m/yr] Maximum allowed ice thickness change due to dynamics
+    margin2nd           = False             ! Apply second-order upwind approximation to gradients at the margin
+    margin_flt_subgrid  = True              ! Allow fractional ice area for floating margins
+    use_bmb             = True              ! Use basal mass balance in mass conservation equation
+    topo_fixed          = False             ! Keep ice thickness fixed, perform other ytopo calculations
+    topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points
+    topo_rel_tau        = 10.0              ! [a] Time scale for relaxation
+    topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
+    bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
     gl_sep              = 1                 ! 1: Linear f_grnd_acx/acy and binary f_grnd, 2: area f_grnd, average to acx/acy
     gz_nx               = 15                ! [-] Number of interpolation points (nx*nx) to calculate grounded area at grounding line
-    gz_Hg0              = 0.0               ! Grounding zone, limit of penetration of bmb_grnd 
-    gz_Hg1              = 100.0             ! Grounding zone, limit of penetration of bmb_shlf 
-    fmb_scale           = 1.0               ! Scaling of fmb ~ scale*bmb, scale=10 suggested by Pollard and DeConto (2016)
-    k2                  = 3e9               ! [m yr] eigen calving scaling factor (Albrecht et al, 2021 recommend 1e17 m s == 3.2e9 m yr)
-    w2                  = 25                ! [-] vm-l19 calving eigenvalue weighting coefficient
-    kt_ref              = 0.0025            ! [m yr-1 Pa-1] vm-l19 calving scaling parameter
-    kt_deep             = 0.1               ! [m yr-1 Pa-1] vm-l19 calving scaling parameter for deep ocean
-    Hc_ref              = 200.0             ! [m] Calving limit in ice thickness (thinner ice calves)
-    Hc_ref_thin         = 50.0              ! [m] Reference ice thickness for thin ice calving
-    Hc_deep             = 500.0             ! [m] Calving limit in ice thickness (thinner ice calves)
-    zb_deep_0           = -1000.0           ! [m] Bedrock elevation to begin transition to deep ocean
-    zb_deep_1           = -1500.0           ! [m] Bedrock elevation to end transition to deep ocean
-    zb_sigma            = 0.0               ! [m] Gaussian filtering of bedrock for calving transition to deep ocean
+    dist_grz            = 200.0             ! [km] Radius to consider part of "grounding-line zone" (grz)
+    gz_Hg0              = 0.0               ! Grounding zone, limit of penetration of bmb_grnd
+    gz_Hg1              = 100.0             ! Grounding zone, limit of penetration of bmb_shlf
+    dmb_method          = 0                 ! 0: no subgrid discharge, 1: subgrid discharge on
     dmb_alpha_max       = 60.0              ! [deg] Maximum angle of slope from coast at which to allow discharge
     dmb_tau             = 100.0             ! [yr]  Discharge timescale
     dmb_sigma_ref       = 300.0             ! [m]   Reference bed roughness
     dmb_m_d             = 3.0               ! [-]   Discharge distance scaling exponent
     dmb_m_r             = 1.0               ! [-]   Discharge resolution scaling exponent
+    fmb_method          = 1                 ! 0: prescribe boundary field fmb_shlf; 1: calculate proportional fmb~bmb_shlf.
+    fmb_scale           = 1.0               ! Scaling of fmb ~ scale*bmb, scale=10 suggested by Pollard and DeConto (2016)
 
+/
+
+&ycalv
+    use_lsf             = False             ! use level-set method
+    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    calv_flt_method     = "vm-l19"          ! "zero", "simple", "flux", "vm-l19", "kill", "threshold"
+    calv_grnd_method    = "stress-b12"      ! "zero", "stress-b12"
+    H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated)
+    H_min_flt           = 0.0               ! [m] Minimum ice thickness at floating margin (thinner ice is ablated)
+    sd_min              = 100.0             ! [m] calv_grnd(z_bed_sd <= sd_min) = 0.0
+    sd_max              = 500.0             ! [m] calv_grnd(z_bed_sd >= sd_max) = calv_max
+    calv_grnd_max       = 0.0               ! [m/a] Maximum grounded calving rate from high stdev(z_bed)
+    calv_tau            = 1.0               ! [a] Characteristic calving time
+    calv_thin           = 30.0              ! [m/yr] Calving rate to apply to very thin ice
+    k2                  = 3e9               ! [m yr] eigen calving scaling factor
+    w2                  = 25                ! [-] vm-l19 calving eigenvalue weighting coefficient
+    kt_ref              = 0.0025            ! [m yr-1 Pa-1] vm-l19 calving scaling parameter
+    kt_deep             = 0.1               ! [m yr-1 Pa-1] vm-l19 calving scaling parameter for deep ocean
+    tau_ice             = 100.0e3           ! [Pa] Ice strength failure
+    Hc_ref_flt          = 200.0             ! [m] Calving limit in floating ice thickness
+    Hc_ref_grnd         = 200.0             ! [m] Calving limit in grounded ice thickness
+    Hc_ref_thin         = 50.0              ! [m] Reference ice thickness for thin ice calving
+    Hc_deep             = 500.0             ! [m] Calving limit in ice thickness for deep ocean
+    zb_deep_0           = -1000.0           ! [m] Bedrock elevation to begin transition to deep ocean
+    zb_deep_1           = -1500.0           ! [m] Bedrock elevation to end transition to deep ocean
+    zb_sigma            = 0.0               ! [m] Gaussian filtering of bedrock for calving transition to deep ocean
 /
 
 &ydyn
     solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", "l1l2", "l1l2-noslip"
+    uz_method           = 3               ! 1: aa-staggering, 2: strain-rate-on-nodes, 3: jacobian
     visc_method         = 1               ! 0: constant visc=visc_const, 1: dynamic viscosity
     visc_const          = 1e7             ! [Pa a] Constant value for viscosity (if visc_method=0)
     beta_method         = 3               ! 0: constant beta; 1: linear (beta=cb/u0); 2: psuedo-plastic-power; 3: Regularized Coulomb
@@ -171,11 +180,14 @@
     beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling 
     beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
     taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
-    H_grnd_lim          = 500.0           ! [m] For For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim 
-    n_sm_beta           = 0               ! [-] Standard deviation in gridpoints for Gaussian smoothing of beta (0==no smoothing)
+    H_grnd_lim          = 500.0           ! [m] For For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim
     beta_min            = 100.0           ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
+    T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
@@ -188,8 +200,9 @@
 /
 
 &ytill
-    method          = 1                 ! -1: set externally; 1: calculate cb_ref online  
-    scale           = "lin"             ! "none", "lin", or "exp" : scaling with elevation 
+    method          = 1                 ! -1: set externally; 1: calculate cb_ref online
+    scale_zb        = 1                 ! 0: none, 1: lin, 2: exp : scaling with elevation
+    scale_sed       = 0                 ! 0: none, 1: min(cb_zb,cb_sed), 2: cb_zb*(lambda_sed*f_sed), 3: 2 but no lower limit
     is_angle        = False             ! cb_ref is a till strength angle?
     n_sd            = 10                ! Number of samples over z_bed_sd field
     f_sed           = 1.0               ! Scaling reduction for thick sediments 
@@ -238,12 +251,11 @@
 
 &ytherm
     method          = "temp"            ! "fixed", "robin", "temp", "enth"
+    qb_method       = 2                 ! 1: simple-stagger, 2: quadrature
     dt_method       = "FE"              ! "FE", "AB", "SAM"
     solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
     gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function 
     use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
-    n_sm_qstrn      = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of strain heating (0==no smoothing)
-    n_sm_qb         = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of basal heating (0==no smoothing)
     use_const_cp    = False             ! Use specified constant value of heat capacity?
     const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
     use_const_kt    = False             ! Use specified constant value of heat conductivity?
@@ -281,6 +293,7 @@
     phys_const      = 'Earth'    
     experiment      = 'None'   
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"
@@ -319,6 +332,7 @@
     phys_const      = "Earth"
     experiment      = "None"            ! "None", "EISMINT1", "MISMIP3D"  to apply special boundary conditions
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"

--- a/par/PMYY_MAG_Bipolar/ZI03/yelmo_bipolar.nml
+++ b/par/PMYY_MAG_Bipolar/ZI03/yelmo_bipolar.nml
@@ -109,54 +109,63 @@
 
 &ytopo
     solver              = "impl-lis"        ! "expl", "impl-lis"
-    calv_flt_method     = "vm-l19"          ! "zero", "simple", "flux", "vm-l19", "kill"
-    calv_grnd_method    = "stress-b12"      ! "zero", "stress-b12"
-    bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
-    fmb_method          = 1                 ! 0: prescribe boundary field fmb_shlf; 1: calculate proportional fmb~bmb_shlf.
-    dmb_method          = 0                 ! 0: no subgrid discharge, 1: subgrid discharge on
     surf_gl_method      = 0                 ! 0: binary (max grnd/flt elevation), 1: subgrid average elevation
-    margin_flt_subgrid  = True              ! Allow fractional ice area for floating margins
-    margin2nd           = False             ! Apply second-order upwind approximation to gradients at the margin
-    use_bmb             = True              ! Use basal mass balance in mass conservation equation
-    topo_fixed          = False             ! Keep ice thickness fixed, perform other ytopo calculations
-    topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
-    topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
-    topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    calv_tau            = 1.0               ! [a] Characteristic calving time
-    calv_thin           = 30.0              ! [m/yr] Calving rate to apply to very thin ice
-    H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated) - helps with stability
-    H_min_flt           = 0.0               ! [m] Minimum ice thickness at floating margin (thinner ice is ablated) - helps with stability
-    sd_min              = 100.0             ! [m] calv_grnd(z_bed_sd <  = sd_min)     = 0.0 
-    sd_max              = 500.0             ! [m] calv_grnd(z_bed_sd >  = sd_max)     = calv_max  
-    calv_grnd_max       = 0.0               ! [m/a] Maximum grounded calving rate from high stdev(z_bed)
     grad_lim            = 0.1               ! [m/m] Maximum allowed sloped in gradient calculations (dz/dx,dH/dx)
     grad_lim_zb         = 0.05              ! [m/m] Maximum allowed sloped in bed gradient (dzb/dx)
-    dist_grz            = 200.0             ! [km] Radius to consider part of "grounding-line zone" (grz)
+    dHdt_dyn_lim        = 100.0             ! [m/yr] Maximum allowed ice thickness change due to dynamics
+    margin2nd           = False             ! Apply second-order upwind approximation to gradients at the margin
+    margin_flt_subgrid  = True              ! Allow fractional ice area for floating margins
+    use_bmb             = True              ! Use basal mass balance in mass conservation equation
+    topo_fixed          = False             ! Keep ice thickness fixed, perform other ytopo calculations
+    topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points
+    topo_rel_tau        = 10.0              ! [a] Time scale for relaxation
+    topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
+    bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
     gl_sep              = 1                 ! 1: Linear f_grnd_acx/acy and binary f_grnd, 2: area f_grnd, average to acx/acy
     gz_nx               = 15                ! [-] Number of interpolation points (nx*nx) to calculate grounded area at grounding line
-    gz_Hg0              = 0.0               ! Grounding zone, limit of penetration of bmb_grnd 
-    gz_Hg1              = 100.0             ! Grounding zone, limit of penetration of bmb_shlf 
-    fmb_scale           = 1.0               ! Scaling of fmb ~ scale*bmb, scale=10 suggested by Pollard and DeConto (2016)
-    k2                  = 3e9               ! [m yr] eigen calving scaling factor (Albrecht et al, 2021 recommend 1e17 m s == 3.2e9 m yr)
-    w2                  = 25                ! [-] vm-l19 calving eigenvalue weighting coefficient
-    kt_ref              = 0.0025            ! [m yr-1 Pa-1] vm-l19 calving scaling parameter
-    kt_deep             = 0.1               ! [m yr-1 Pa-1] vm-l19 calving scaling parameter for deep ocean
-    Hc_ref              = 200.0             ! [m] Calving limit in ice thickness (thinner ice calves)
-    Hc_ref_thin         = 50.0              ! [m] Reference ice thickness for thin ice calving
-    Hc_deep             = 500.0             ! [m] Calving limit in ice thickness (thinner ice calves)
-    zb_deep_0           = -1000.0           ! [m] Bedrock elevation to begin transition to deep ocean
-    zb_deep_1           = -1500.0           ! [m] Bedrock elevation to end transition to deep ocean
-    zb_sigma            = 0.0               ! [m] Gaussian filtering of bedrock for calving transition to deep ocean
+    dist_grz            = 200.0             ! [km] Radius to consider part of "grounding-line zone" (grz)
+    gz_Hg0              = 0.0               ! Grounding zone, limit of penetration of bmb_grnd
+    gz_Hg1              = 100.0             ! Grounding zone, limit of penetration of bmb_shlf
+    dmb_method          = 0                 ! 0: no subgrid discharge, 1: subgrid discharge on
     dmb_alpha_max       = 60.0              ! [deg] Maximum angle of slope from coast at which to allow discharge
     dmb_tau             = 100.0             ! [yr]  Discharge timescale
     dmb_sigma_ref       = 300.0             ! [m]   Reference bed roughness
     dmb_m_d             = 3.0               ! [-]   Discharge distance scaling exponent
     dmb_m_r             = 1.0               ! [-]   Discharge resolution scaling exponent
+    fmb_method          = 1                 ! 0: prescribe boundary field fmb_shlf; 1: calculate proportional fmb~bmb_shlf.
+    fmb_scale           = 1.0               ! Scaling of fmb ~ scale*bmb, scale=10 suggested by Pollard and DeConto (2016)
 
+/
+
+&ycalv
+    use_lsf             = False             ! use level-set method
+    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    calv_flt_method     = "vm-l19"          ! "zero", "simple", "flux", "vm-l19", "kill", "threshold"
+    calv_grnd_method    = "stress-b12"      ! "zero", "stress-b12"
+    H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated)
+    H_min_flt           = 0.0               ! [m] Minimum ice thickness at floating margin (thinner ice is ablated)
+    sd_min              = 100.0             ! [m] calv_grnd(z_bed_sd <= sd_min) = 0.0
+    sd_max              = 500.0             ! [m] calv_grnd(z_bed_sd >= sd_max) = calv_max
+    calv_grnd_max       = 0.0               ! [m/a] Maximum grounded calving rate from high stdev(z_bed)
+    calv_tau            = 1.0               ! [a] Characteristic calving time
+    calv_thin           = 30.0              ! [m/yr] Calving rate to apply to very thin ice
+    k2                  = 3e9               ! [m yr] eigen calving scaling factor
+    w2                  = 25                ! [-] vm-l19 calving eigenvalue weighting coefficient
+    kt_ref              = 0.0025            ! [m yr-1 Pa-1] vm-l19 calving scaling parameter
+    kt_deep             = 0.1               ! [m yr-1 Pa-1] vm-l19 calving scaling parameter for deep ocean
+    tau_ice             = 100.0e3           ! [Pa] Ice strength failure
+    Hc_ref_flt          = 200.0             ! [m] Calving limit in floating ice thickness
+    Hc_ref_grnd         = 200.0             ! [m] Calving limit in grounded ice thickness
+    Hc_ref_thin         = 50.0              ! [m] Reference ice thickness for thin ice calving
+    Hc_deep             = 500.0             ! [m] Calving limit in ice thickness for deep ocean
+    zb_deep_0           = -1000.0           ! [m] Bedrock elevation to begin transition to deep ocean
+    zb_deep_1           = -1500.0           ! [m] Bedrock elevation to end transition to deep ocean
+    zb_sigma            = 0.0               ! [m] Gaussian filtering of bedrock for calving transition to deep ocean
 /
 
 &ydyn
     solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", "l1l2", "l1l2-noslip"
+    uz_method           = 3               ! 1: aa-staggering, 2: strain-rate-on-nodes, 3: jacobian
     visc_method         = 1               ! 0: constant visc=visc_const, 1: dynamic viscosity
     visc_const          = 1e7             ! [Pa a] Constant value for viscosity (if visc_method=0)
     beta_method         = 3               ! 0: constant beta; 1: linear (beta=cb/u0); 2: psuedo-plastic-power; 3: Regularized Coulomb
@@ -167,11 +176,14 @@
     beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling 
     beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
     taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
-    H_grnd_lim          = 500.0           ! [m] For For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim 
-    n_sm_beta           = 0               ! [-] Standard deviation in gridpoints for Gaussian smoothing of beta (0==no smoothing)
+    H_grnd_lim          = 500.0           ! [m] For For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim
     beta_min            = 100.0           ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
+    T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
@@ -184,8 +196,9 @@
 /
 
 &ytill
-    method          = 1                 ! -1: set externally; 1: calculate cb_ref online  
-    scale           = "lin"             ! "none", "lin", or "exp" : scaling with elevation 
+    method          = 1                 ! -1: set externally; 1: calculate cb_ref online
+    scale_zb        = 1                 ! 0: none, 1: lin, 2: exp : scaling with elevation
+    scale_sed       = 0                 ! 0: none, 1: min(cb_zb,cb_sed), 2: cb_zb*(lambda_sed*f_sed), 3: 2 but no lower limit
     is_angle        = False             ! cb_ref is a till strength angle?
     n_sd            = 10                ! Number of samples over z_bed_sd field
     f_sed           = 1.0               ! Scaling reduction for thick sediments 
@@ -234,12 +247,11 @@
 
 &ytherm
     method          = "temp"            ! "fixed", "robin", "temp", "enth"
+    qb_method       = 2                 ! 1: simple-stagger, 2: quadrature
     dt_method       = "FE"              ! "FE", "AB", "SAM"
     solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
     gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function 
     use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
-    n_sm_qstrn      = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of strain heating (0==no smoothing)
-    n_sm_qb         = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of basal heating (0==no smoothing)
     use_const_cp    = False             ! Use specified constant value of heat capacity?
     const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
     use_const_kt    = False             ! Use specified constant value of heat conductivity?
@@ -277,6 +289,7 @@
     phys_const      = 'Earth'    
     experiment      = 'None'   
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"
@@ -315,6 +328,7 @@
     phys_const      = "Earth"
     experiment      = "None"            ! "None", "EISMINT1", "MISMIP3D"  to apply special boundary conditions
     nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
     nml_ydyn        = "ydyn"
     nml_ytill       = "ytill"
     nml_yneff       = "yneff"

--- a/par/yelmo_Antarctica.nml
+++ b/par/yelmo_Antarctica.nml
@@ -193,8 +193,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_Antarctica_esm.nml
+++ b/par/yelmo_Antarctica_esm.nml
@@ -157,8 +157,7 @@
     pc_corr_vel     = False             ! Calculate dynamics again for corrected H_ice
     pc_n_redo       = 5                 ! How many times can the same iteration be repeated (when high error exists)
     pc_tol          = 5.0               ! [m/a] Tolerance threshold to redo timestep
-    pc_eps          = 1.0               ! Predictor-corrector tolerance 
-    n_reg           = 0                 ! Number of regions for 1D output
+    pc_eps          = 1.0               ! Predictor-corrector tolerance
 
 /
 
@@ -234,6 +233,7 @@
 
 &ydyn
     solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", "l1l2", "l1l2-noslip"
+    uz_method           = 3               ! 1: aa-staggering, 2: strain-rate-on-nodes, 3: jacobian
     visc_method         = 1               ! 0: constant visc=visc_const, 1: dynamic viscosity
     visc_const          = 1e7             ! [Pa a] Constant value for viscosity (if visc_method=0)
     beta_method         = 3               ! 0: constant beta; 1: linear (beta=cb/u0); 2: psuedo-plastic-power; 3: Regularized Coulomb
@@ -244,12 +244,14 @@
     beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling 
     beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
     taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
-    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim 
-    n_sm_beta           = 0               ! [-] Standard deviation in gridpoints for Gaussian smoothing of beta (0==no smoothing)
+    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim
     beta_min            = 100            ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
+    T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
@@ -262,8 +264,9 @@
 /
 
 &ytill
-    method          =  -1               ! -1: set externally; 1: calculate cb_ref online  
-    scale           = "none"            ! "none", "lin", or "exp" : scaling with elevation 
+    method          =  -1               ! -1: set externally; 1: calculate cb_ref online
+    scale_zb        = 0                 ! 0: none, 1: lin, 2: exp : scaling with elevation
+    scale_sed       = 0                 ! 0: none, 1: min(cb_zb,cb_sed), 2: cb_zb*(lambda_sed*f_sed), 3: 2 but no lower limit
     is_angle        = False             ! cb_ref is a till strength angle?
     n_sd            = 10                ! Number of samples over z_bed_sd field
     f_sed           = 1.0               ! Scaling reduction for thick sediments 
@@ -312,12 +315,11 @@
 
 &ytherm
     method          = "temp"            ! "fixed", "robin", "temp", "enth"
+    qb_method       = 2                 ! 1: simple-stagger, 2: quadrature
     dt_method       = "FE"              ! "FE", "AB", "SAM"
     solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
     gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function 
     use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
-    n_sm_qstrn      = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of strain heating (0==no smoothing)
-    n_sm_qb         = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of basal heating (0==no smoothing)
     use_const_cp    = False             ! Use specified constant value of heat capacity?
     const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
     use_const_kt    = False             ! Use specified constant value of heat conductivity?

--- a/par/yelmo_Antarctica_nudge.nml
+++ b/par/yelmo_Antarctica_nudge.nml
@@ -160,8 +160,7 @@
     pc_corr_vel     = False             ! Calculate dynamics again for corrected H_ice
     pc_n_redo       = 5                 ! How many times can the same iteration be repeated (when high error exists)
     pc_tol          = 5.0               ! [m/a] Tolerance threshold to redo timestep
-    pc_eps          = 1.0               ! Predictor-corrector tolerance 
-    n_reg           = 0                 ! Number of regions for 1D output
+    pc_eps          = 1.0               ! Predictor-corrector tolerance
 
 /
 
@@ -237,6 +236,7 @@
 
 &ydyn
     solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", "l1l2", "l1l2-noslip"
+    uz_method           = 3               ! 1: aa-staggering, 2: strain-rate-on-nodes, 3: jacobian
     visc_method         = 1               ! 0: constant visc=visc_const, 1: dynamic viscosity
     visc_const          = 1e7             ! [Pa a] Constant value for viscosity (if visc_method=0)
     beta_method         = 3               ! 0: constant beta; 1: linear (beta=cb/u0); 2: psuedo-plastic-power; 3: Regularized Coulomb
@@ -247,12 +247,14 @@
     beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling 
     beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
     taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
-    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim 
-    n_sm_beta           = 0               ! [-] Standard deviation in gridpoints for Gaussian smoothing of beta (0==no smoothing)
+    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim
     beta_min            = 100            ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
+    T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
@@ -265,8 +267,9 @@
 /
 
 &ytill
-    method          =  -1               ! -1: set externally; 1: calculate cb_ref online  
-    scale           = "none"            ! "none", "lin", or "exp" : scaling with elevation 
+    method          =  -1               ! -1: set externally; 1: calculate cb_ref online
+    scale_zb        = 0                 ! 0: none, 1: lin, 2: exp : scaling with elevation
+    scale_sed       = 0                 ! 0: none, 1: min(cb_zb,cb_sed), 2: cb_zb*(lambda_sed*f_sed), 3: 2 but no lower limit
     is_angle        = False             ! cb_ref is a till strength angle?
     n_sd            = 10                ! Number of samples over z_bed_sd field
     f_sed           = 1.0               ! Scaling reduction for thick sediments 
@@ -315,12 +318,11 @@
 
 &ytherm
     method          = "temp"            ! "fixed", "robin", "temp", "enth"
+    qb_method       = 2                 ! 1: simple-stagger, 2: quadrature
     dt_method       = "FE"              ! "FE", "AB", "SAM"
     solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
     gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function 
     use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
-    n_sm_qstrn      = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of strain heating (0==no smoothing)
-    n_sm_qb         = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of basal heating (0==no smoothing)
     use_const_cp    = False             ! Use specified constant value of heat capacity?
     const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
     use_const_kt    = False             ! Use specified constant value of heat conductivity?

--- a/par/yelmo_Antarctica_rtip.nml
+++ b/par/yelmo_Antarctica_rtip.nml
@@ -135,11 +135,21 @@
 /
 &yelmo
  domain          = 'Antarctica'
- grid_name       = 'ANT-16KM' 
+ grid_name       = 'ANT-16KM'
  grid_path       = 'ice_data/{domain}/{grid_name}/{grid_name}_REGIONS.nc'
- phys_const      = 'Earth'    
- experiment      = 'None'     
- restart         = 'None'     
+ phys_const      = 'Earth'
+ experiment      = 'None'
+ nml_ytopo       = 'ytopo'
+ nml_ycalv       = 'ycalv'
+ nml_ydyn        = 'ydyn'
+ nml_ytill       = 'ytill'
+ nml_yneff       = 'yneff'
+ nml_ymat        = 'ymat'
+ nml_ytherm      = 'ytherm'
+ nml_masks       = 'yelmo_masks'
+ nml_init_topo   = 'yelmo_init_topo'
+ nml_data        = 'yelmo_data'
+ restart         = 'None'
  restart_z_bed   = .true.     
  restart_H_ice   = .true.     
  restart_relax   = 1000.0     
@@ -175,7 +185,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -251,8 +260,9 @@
  eps_0           = 1e-06
  scale_T         = 1
 T_frz            = -3.0     
- ssa_lis_opt     = '-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false'
- ssa_solver      = 'energy'        ! 'residual' | 'energy'
+ ssa_solver           = 'energy'       ! 'residual' | 'energy'
+ ssa_lis_opt_residual = '-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false'
+ ssa_lis_opt_energy   = '-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false'
  ssa_lat_bc      = 'all'      
  ssa_beta_max    = 1e+20      
  ssa_vel_max     = 5000.0     

--- a/par/yelmo_Greenland.nml
+++ b/par/yelmo_Greenland.nml
@@ -192,8 +192,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_Greenland_rembo.nml
+++ b/par/yelmo_Greenland_rembo.nml
@@ -137,7 +137,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -213,8 +212,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_LIS.nml
+++ b/par/yelmo_LIS.nml
@@ -85,7 +85,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -161,8 +160,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-1 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-1 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_North.nml
+++ b/par/yelmo_North.nml
@@ -85,7 +85,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -161,8 +160,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-1 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-1 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_Pyrenees.nml
+++ b/par/yelmo_Pyrenees.nml
@@ -185,8 +185,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_bipolar.nml
+++ b/par/yelmo_bipolar.nml
@@ -136,7 +136,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -212,8 +211,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = '-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false'  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = 'energy'        ! 'residual' | 'energy'
+    ssa_solver           = 'energy'       ! 'residual' | 'energy'
+    ssa_lis_opt_residual = '-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false'  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = '-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false'       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = 'all'           ! 'all', 'marine', 'floating', 'none', 'slab'
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_ismip6_Antarctica.nml
+++ b/par/yelmo_ismip6_Antarctica.nml
@@ -152,7 +152,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -228,8 +227,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_nahosmip_Antarctica.nml
+++ b/par/yelmo_nahosmip_Antarctica.nml
@@ -152,7 +152,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -228,8 +227,9 @@
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 

--- a/par/yelmo_pd_Antarctica.nml
+++ b/par/yelmo_pd_Antarctica.nml
@@ -79,9 +79,9 @@
     nml_yneff       = "yneff"
     nml_ymat        = "ymat"
     nml_ytherm      = "ytherm"
-    nml_masks       = "yelmo_masks_south"
-    nml_init_topo   = "yelmo_init_topo_south"
-    nml_data        = "yelmo_data_south"  
+    nml_masks       = "yelmo_masks"
+    nml_init_topo   = "yelmo_init_topo"
+    nml_data        = "yelmo_data"
     restart         = "None"
     restart_z_bed   = True              ! Take z_bed (and z_bed_sd) from restart file
     restart_H_ice   = True              ! Take H_ice from restart file
@@ -119,7 +119,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -190,14 +189,14 @@
     beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling 
     beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
     taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
-    H_grnd_lim          = 500.0           ! [m] For For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim 
-    n_sm_beta           = 0               ! [-] Standard deviation in gridpoints for Gaussian smoothing of beta (0==no smoothing)
+    H_grnd_lim          = 500.0           ! [m] For For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim
     beta_min            = 100.0           ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
@@ -266,8 +265,6 @@
     solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
     gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function 
     use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
-    n_sm_qstrn      = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of strain heating (0==no smoothing)
-    n_sm_qb         = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of basal heating (0==no smoothing)
     use_const_cp    = False             ! Use specified constant value of heat capacity?
     const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
     use_const_kt    = False             ! Use specified constant value of heat conductivity?

--- a/par/yelmo_pd_Greenland.nml
+++ b/par/yelmo_pd_Greenland.nml
@@ -113,9 +113,9 @@
     nml_yneff       = "yneff"
     nml_ymat        = "ymat"
     nml_ytherm      = "ytherm"
-    nml_masks       = "yelmo_masks_north"
-    nml_init_topo   = "yelmo_init_topo_north"
-    nml_data        = "yelmo_data_north"  
+    nml_masks       = "yelmo_masks"
+    nml_init_topo   = "yelmo_init_topo"
+    nml_data        = "yelmo_data"
     restart         = 'none'     
     restart_z_bed   = .true.     
     restart_H_ice   = .true.     
@@ -152,7 +152,6 @@
     topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points 
     topo_rel_tau        = 10.0              ! [a] Time scale for relaxation 
     topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
-    grounded_melt       = True
 
     ! === Grounding line ===
     bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
@@ -223,14 +222,14 @@
     beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling, 4: vel weighting 
     beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
     taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
-    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim 
-    n_sm_beta           = 0               ! [-] Standard deviation in gridpoints for Gaussian smoothing of beta (0==no smoothing)
+    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim
     beta_min            = 100.0           ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
     eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
     scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
     T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
-    ssa_lis_opt         = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
-    ssa_solver          = "energy"        ! "residual" | "energy"
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
     ssa_lat_bc          = "all"           ! "all", "marine", "floating", "none", "slab"
     ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated 
     ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results 
@@ -299,8 +298,6 @@
     solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
     gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function 
     use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
-    n_sm_qstrn      = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of strain heating (0==no smoothing)
-    n_sm_qb         = 0                 ! [-] Standard deviation in gridpoints for Gaussian smoothing of basal heating (0==no smoothing)
     use_const_cp    = False             ! Use specified constant value of heat capacity?
     const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
     use_const_kt    = False             ! Use specified constant value of heat conductivity?


### PR DESCRIPTION
## Summary
Brings all 16 yelmox parameter files into alignment with the current yelmo source schema (`yelmo/src/`).

### ydyn — SSA solver options
- Split single `ssa_lis_opt` into `ssa_lis_opt_residual` + `ssa_lis_opt_energy` (matches yelmo refactor).
- Place `ssa_solver` before the LIS option lines.

### Missing params added (using values from `yelmo_Antarctica.nml` as reference)
- `ydyn`: `uz_method`, `scale_T`, `T_frz`
- `ytill`: `scale_zb`, `scale_sed`
- `ytherm`: `qb_method`
- `ytopo` (PMYY only): `dHdt_dyn_lim`

### Obsolete params removed (no longer read by yelmo)
- `grounded_melt`, `n_sm_beta`, `n_sm_qb`, `n_sm_qstrn`, `n_reg`, old single `scale` in ytill

### Structural fixes
- `yelmo_pd_Antarctica.nml` / `yelmo_pd_Greenland.nml`: dropped stale `_south`/`_north` suffix from `nml_masks/init_topo/data` so they point to the groups that actually exist in the file.
- `yelmo_Antarctica_rtip.nml`: added all 10 missing `nml_X` references in `&yelmo` (file would not load otherwise).
- `par/PMYY_MAG_Bipolar/*/yelmo_bipolar.nml`: moved calving params out of `&ytopo` into a new `&ycalv` group; split `Hc_ref` into `Hc_ref_grnd`/`Hc_ref_flt`; added `use_lsf=False` (preserves original non-LSF behavior), `dt_lsf`, `tau_ice`; wired `nml_ycalv = "ycalv"` in `&yelmo_north`/`&yelmo_south`.

A verification script comparing each file to the schema extracted from `yelmo/src/` reports all 16 files as OK.

## Test plan
- [ ] Run a yelmox simulation against each updated par file (or at minimum the ones in active use) to confirm yelmo loads the namelist without missing-param errors.
- [ ] Spot-check that param values produce expected behavior (no unintended change of regime — especially PMYY where calving block was restructured).