### PR TITLE
Add SPI par file and lsf_method/lsf_redist_n_iter to all par files

### DIFF
--- a/par/PMYY_MAG_Bipolar/OBM_hyster_forcby_ISM/yelmo_bipolar.nml
+++ b/par/PMYY_MAG_Bipolar/OBM_hyster_forcby_ISM/yelmo_bipolar.nml
@@ -143,7 +143,9 @@
 
 &ycalv
     use_lsf             = False             ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-l19"          ! "zero", "simple", "flux", "vm-l19", "kill", "threshold"
     calv_grnd_method    = "stress-b12"      ! "zero", "stress-b12"
     H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated)

--- a/par/PMYY_MAG_Bipolar/ZI03/yelmo_bipolar.nml
+++ b/par/PMYY_MAG_Bipolar/ZI03/yelmo_bipolar.nml
@@ -139,7 +139,9 @@
 
 &ycalv
     use_lsf             = False             ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-l19"          ! "zero", "simple", "flux", "vm-l19", "kill", "threshold"
     calv_grnd_method    = "stress-b12"      ! "zero", "stress-b12"
     H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated)

--- a/par/yelmo_Antarctica.nml
+++ b/par/yelmo_Antarctica.nml
@@ -145,7 +145,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "equil"           ! "zero", "simple", "flux", "vm-l19", "kill", "threshold"
     calv_grnd_method    = "equil"           ! "zero", "stress-b12"
     

--- a/par/yelmo_Antarctica_esm.nml
+++ b/par/yelmo_Antarctica_esm.nml
@@ -201,7 +201,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "equil"           ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "equil"           ! "zero", "stress-b12"
     

--- a/par/yelmo_Antarctica_nudge.nml
+++ b/par/yelmo_Antarctica_nudge.nml
@@ -204,7 +204,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "equil"           ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "equil"           ! "zero", "stress-b12"
     

--- a/par/yelmo_Antarctica_rtip.nml
+++ b/par/yelmo_Antarctica_rtip.nml
@@ -212,7 +212,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_Greenland.nml
+++ b/par/yelmo_Greenland.nml
@@ -144,7 +144,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "equil"           ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "equil"           ! "zero", "stress-b12"
     

--- a/par/yelmo_Greenland_rembo.nml
+++ b/par/yelmo_Greenland_rembo.nml
@@ -164,7 +164,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_LIS.nml
+++ b/par/yelmo_LIS.nml
@@ -112,7 +112,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_North.nml
+++ b/par/yelmo_North.nml
@@ -112,7 +112,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_Pyrenees.nml
+++ b/par/yelmo_Pyrenees.nml
@@ -137,7 +137,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = False              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "zero"            ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_SPI_lia_new.nml
+++ b/par/yelmo_SPI_lia_new.nml
@@ -1,0 +1,571 @@
+
+
+&ctrl
+    time_init       = 0.0               ! [yr] Starting time
+    time_end        = 200.0              ! [yr] Ending time
+    time_equil      = 2e3               ! [yr] Equilibration time
+    time_const      = 1950.0            ! [yr CE] Assumed constant time for non-transient climate (-19050 == 21 kyr ago)
+    time_lgm_step   = 15e3              ! [yr] Time to switch time_const => -19050 (21 kyr ago)
+    time_pd_step    = 30e3              ! [yr] Time to switch time_const => 1950.0 (PD, 0 kyr ago)
+    dtt             = 5.0              ! [yr] Main loop timestep
+    dt1D_out        = 10.0             ! [yr] Frequency of writing 1D output files
+    dt2D_out        = 100.0               ! [yr] Frequency of writing 2D output files
+    dt2D_small_out  = 10.0               ! [yr] Frequency of writing 2D output files
+    dt_restart      = 20e3              ! [yr] Frequency of writing restart files
+    transient_clim  = False             ! Calculate transient climate?
+    use_lgm_step    = False             ! Activate LGM step in forcing at time=time_lgm_step?
+    use_pd_step     = False             ! Activate PD step-return in forcing at time=time_pd_step?
+    with_ice_sheet  = True              ! Is the ice sheet active?
+    equil_method    = "none"            ! "none", "relax", "opt"
+/
+
+&tm_1D
+    method          = "const"           ! "const", "file", "times"
+    dt              = 1.0
+    file            = "input/timeout_ramp_100kyr.txt"
+    times           = -10, -5, 0, 1, 2, 3, 4, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55
+/
+
+&tm_2D
+    method          = "const"           ! "const", "file", "times"
+    dt              = 200.0
+    file            = "input/timeout_ramp_100kyr.txt"
+    times           = 0
+/
+
+&tm_2Dsm
+    method          = "const"           ! "const", "file", "times"
+    dt              = 50.0
+    file            = "input/timeout_ramp_100kyr.txt"
+    times           = 0
+/
+
+&opt
+    opt_cf          = True              ! Should basal friction be optimized?
+    cf_time_init    = 0.0               ! [yr] When should optimization of basal friction start?
+    cf_time_end     = 8e3              ! [yr] When should optimization of basal friction stop?
+    cf_init         = -1.0              ! Initial value of cf_ref everywhere (negative uses cb_tgt)
+    cf_min          = 1e-3             ! [--] Minimum allowed cf value
+    tau_c           = 500.0             ! [yr] L21: Optimization relaxation timescale 
+    H0              = 100.0             ! [m]  L21: Optimization ice-thickness error scaling 
+    
+    sigma_err       = 50e3              ! [m] Smoothing radius for error to calculate correction in cf_ref
+    sigma_vel       = 100.0             ! [m/yr] Speed at which smoothing diminishes to zero
+    fill_method     = "cf_min"          ! nearest, analog, target, cf_min
+    
+    rel_tau1        = 100.0             ! [yr] Relaxation timescale in time period 1
+    rel_tau2        = 2000.0            ! [yr] Relaxation timescale in time period 2
+    rel_time1       = 2e3               ! [yr] Time limit for time period 1
+    rel_time2       = 6e3               ! [yr] Time limit for time period 2
+    rel_m           = 2.0               ! [--] Non-linear exponent to scale interpolation of rel_tau between time1 and time2 
+
+    opt_tf          = False             ! Should thermal forcing be optimized too?
+    tf_time_init    = 0.0               ! [yr] When should optimization of thermal forcing start?
+    tf_time_end     = 25e3              ! [yr] When should optimization of thermal forcing stop?
+    tf_time         = 25e3              ! [yr] When should optimization of thermal forcing stop?
+    H_grnd_lim      = 500.0             ! [m] Distance from grounding line to consider in terms of thickness above flotation
+    tf_sigma        = 50e3              ! [m] Smoothing radius for error to calculate tf_corr
+    tau_m           = 100.0             ! [yr] Optimization relxation timescale 
+    m_temp          = 10.0              ! [m yr^−1 degC^−1] Optimization scaling value
+    tf_min          = -0.5              ! [degC] Minimum allowed tf_corr value 
+    tf_max          =  0.5              ! [degC] Maximum allowed tf_corr value 
+    tf_basins       = -1.               ! Basin numbers to optimize (-1 for all basins)
+
+    cf_ref_wais     = 0.01
+/
+
+&yelmo
+    domain          = "SPI"
+    grid_name       = "SPI-1KM"
+    grid_path       = "ice_data/{domain}/{grid_name}/{grid_name}_REGIONS.nc"
+    experiment      = "None"            ! "None", "EISMINT1", "MISMIP3D"  to apply special boundary conditions
+    phys_const      = "Earth"
+    nml_ytopo       = "ytopo"
+    nml_ycalv       = "ycalv"
+    nml_ydyn        = "ydyn"
+    nml_ytill       = "ytill"
+    nml_yneff       = "yneff"
+    nml_ymat        = "ymat"
+    nml_ytherm      = "ytherm"
+    nml_masks       = "yelmo_masks"
+    nml_init_topo   = "yelmo_init_topo"
+    nml_data        = "yelmo_data"
+    restart         = "None"
+    restart_z_bed   = True              ! Take z_bed (and z_bed_sd) from restart file
+    restart_H_ice   = True              ! Take H_ice from restart file
+    restart_relax   = 500.0             ! [yrs] Years to relax from restart=>input topography
+    log_timestep    = False 
+    disable_kill    = False             ! Disable automatic kill if unstable
+    zeta_scale      = "exp"             ! "linear", "exp", "tanh"
+    zeta_exp        = 2.0  
+    nz_aa           = 6                 ! Vertical resolution in ice
+    dt_method       = 2                 ! 0: no internal timestep, 1: adaptive, cfl, 2: adaptive, pc
+    dt_min          = 0.01              ! [a] Minimum timestep 
+    cfl_max         = 0.5               ! Maximum value is 1.0, lower will be more stable
+    cfl_diff_max    = 0.12              ! Bueler et al (2007), Eq. 25  
+    pc_method       = "AB-SAM"          ! "FE-SBE", "AB-SAM", "HEUN"
+    pc_controller   = "PI42"            ! PI42, H312b, H312PID, H321PID, PID1
+    pc_use_H_pred   = True              ! Use predicted H_ice instead of corrected H_ice 
+    pc_filter_vel   = True              ! Use mean vel. solution of current and previous timestep
+    pc_corr_vel     = False             ! Calculate dynamics again for corrected H_ice
+    pc_n_redo       = 5                 ! How many times can the same iteration be repeated (when high error exists)
+    pc_tol          = 5.0               ! [m/a] Tolerance threshold to redo timestep
+    pc_eps          = 1.0               ! Predictor-corrector tolerance 
+    
+/
+
+&ytopo
+    solver              = "impl-lis"        ! "expl", "impl-lis"
+    surf_gl_method      = 0                 ! 0: binary (max grnd/flt elevation), 1: subgrid average elevation
+    grad_lim            = 0.1               ! [m/m] Maximum allowed sloped in gradient calculations (dz/dx,dH/dx)
+    grad_lim_zb         = 0.05              ! [m/m] Maximum allowed sloped in bed gradient (dzb/dx)
+    dHdt_dyn_lim        = 100.0             ! [m/yr] Maximum allowed ice thickness change due to dynamics
+    margin2nd           = False             ! Apply second-order upwind approximation to gradients at the margin
+    margin_flt_subgrid  = True              ! Allow fractional ice area for floating margins
+    use_bmb             = True              ! Use basal mass balance in mass conservation equation
+    topo_fixed          = False             ! Keep ice thickness fixed, perform other ytopo calculations
+    topo_rel            = 0                 ! 0: No relaxation; 1: relax shelf; 2: relax shelf + gl; 3: all points
+    topo_rel_tau        = 10.0              ! [a] Time scale for relaxation
+    topo_rel_field      = "H_ref"           ! "H_ref" or "H_ice_n"
+
+    ! === Grounding line ===
+    bmb_gl_method       = "pmp"             ! "fcmp": flotation; "fmp": full melt; "pmp": partial melt; "nmp": no melt
+    gl_sep              = 1                 ! 1: Linear f_grnd_acx/acy and binary f_grnd, 2: area f_grnd, average to acx/acy
+    gz_nx               = 15                ! [-] Number of interpolation points (nx*nx) to calculate grounded area at grounding line
+
+    ! bmb_gl_method = pmp
+    dist_grz            = 200.0             ! [km] Radius to consider part of "grounding-line zone" (grz)
+    gz_Hg0              = 0.0               ! Grounding zone, limit of penetration of bmb_grnd
+    gz_Hg1              = 100.0             ! Grounding zone, limit of penetration of bmb_shlf
+
+    ! === discharge mass balance ===
+    dmb_method          = 0                 ! 0: no subgrid discharge, 1: subgrid discharge on
+    dmb_alpha_max       = 60.0              ! [deg] Maximum angle of slope from coast at which to allow discharge
+    dmb_tau             = 100.0             ! [yr]  Discharge timescale
+    dmb_sigma_ref       = 300.0             ! [m]   Reference bed roughness
+    dmb_m_d             = 3.0               ! [-]   Discharge distance scaling exponent
+    dmb_m_r             = 1.0               ! [-]   Discharge resolution scaling exponent
+
+    ! === frontal mass melt ===
+    fmb_method          = 1                 ! 0: prescribe boundary field fmb_shlf; 1: calculate proportional fmb~bmb_shlf.
+    fmb_scale           = 1.0               ! Scaling of fmb ~ scale*bmb, scale=10 suggested by Pollard and DeConto (2016)
+/
+
+&ycalv
+    ! === calving method & law ===
+    use_lsf             = False             ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
+    dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
+    calv_flt_method     = "vm-l19"          ! "zero", "simple", "flux", "vm-l19", "kill"
+    calv_grnd_method    = "zero"            ! "zero", "stress-b12"
+
+    ! === numeric noise ===
+    H_min_grnd          = 5.0               ! [m] Minimum ice thickness at grounded margin (thinner ice is ablated) - helps with stability
+    H_min_flt           = 0.0               ! [m] Minimum ice thickness at floating margin (thinner ice is ablated) - helps with stability
+    sd_min              = 100.0             ! [m] calv_grnd(z_bed_sd <= sd_min) = 0.0
+    sd_max              = 500.0             ! [m] calv_grnd(z_bed_sd >= sd_max) = calv_max
+    calv_grnd_max       = 0.0               ! [m/a] Maximum grounded calving rate from high stdev(z_bed)
+
+    ! ===
+    calv_tau            = 1.0               ! [a] Characteristic calving time
+    calv_thin           = 30.0              ! [m/yr] Calving rate to apply to very thin ice
+    k2                  = 3e9               ! [m yr] eigen calving scaling factor (Albrecht et al, 2021 recommend 1e17 m s == 3.2e9 m yr)
+    w2                  = 25                ! [-] vm-l19 calving eigenvalue weighting coefficient
+    kt_ref              = 0.0025            ! [m yr-1 Pa-1] vm-l19 calving scaling parameter
+    kt_deep             = 0.1               ! [m yr-1 Pa-1] vm-l19 calving scaling parameter for deep ocean
+    tau_ice             = 85.0e3            ! [Pa] Ice strength failure
+
+    ! === threshold method ===
+    Hc_ref_flt          = 200.0             ! [m] Calving limit in floating ice thickness (thinner ice calves)
+    Hc_ref_grnd         = 200.0             ! [m] Calving limit in grounded ice thickness (thinner ice calves)
+    Hc_ref_thin         = 50.0              ! [m] Reference ice thickness for thin ice calving
+    Hc_deep             = 500.0             ! [m] Calving limit in ice thickness (thinner ice calves)
+    zb_deep_0           = -1000.0           ! [m] Bedrock elevation to begin transition to deep ocean
+    zb_deep_1           = -1500.0           ! [m] Bedrock elevation to end transition to deep ocean
+    zb_sigma            = 0.0               ! [m] Gaussian filtering of bedrock for calving transition to deep ocean
+/
+
+&ydyn
+    solver              = "diva"          ! "fixed", "sia", "ssa", "hybrid", "diva", "diva-noslip", "l1l2", "l1l2-noslip"
+    uz_method           = 3               ! 1: aa-staggering, 2: strain-rate-on-nodes, 3: jacobian
+    visc_method         = 1               ! 0: constant visc=visc_const, 1: dynamic viscosity
+    visc_const          = 1e7             ! [Pa a] Constant value for viscosity (if visc_method=0)
+    beta_method         = 3               ! 0: constant beta; 1: linear (beta=cb/u0); 2: psuedo-plastic-power; 3: Regularized Coulomb
+    beta_const          = 1e3             ! [Pa a m−1] Constant value of basal friction coefficient to be used
+    beta_q              = 0.729           ! Dragging law exponent
+    beta_u0             = 34.84           ! [m/a] Regularization term for regularized Coulomb law (beta_method=3)
+    beta_gl_scale       = 0               !  0: beta*beta_gl_f, 1: H_grnd linear scaling, 2: Zstar scaling
+    beta_gl_stag        = 3               !  0: simple staggering, 1: Upstream beta at gl, 2: downstream, 3: f_grnd_ac scaling
+    beta_gl_f           = 1.0             ! [-] Scaling of beta at the grounding line (for beta_gl_scale=0)
+    taud_gl_method      = 0               !  0: binary, no subgrid, 1: Two-sided gradient
+    H_grnd_lim          = 500.0           ! [m] For beta_gl_scale=1, reduce beta linearly between H_grnd=0 and H_grnd_lim
+    beta_min            = 100.0           ! [Pa a m-1] Minimum value of beta allowed for grounded ice (for stability)
+    eps_0               = 1e-6            ! [1/a] Regularization term for effective viscosity - minimum strain rate
+    scale_T             = 1               ! 0: no scaling of c_bed with T, 1: linearly increase c_bed to c_bed_frozen=cf_ref*N_eff for cold ice
+    T_frz               = -3.0            ! Temperature below which ice considered fully frozen (linear increase in friction )
+    ssa_solver           = "energy"       ! "residual" | "energy"
+    ssa_lis_opt_residual = "-i minres -p jacobi -maxiter 100 -tol 1.0e-2 -initx_zeros false"  ! See Lis library !-omp_num_threads 2
+    ssa_lis_opt_energy   = "-i cg -p jacobi -maxiter 200 -tol 1.0e-4 -initx_zeros false"       ! SPD => CG (matches Yelmo.jl default)
+    ssa_lat_bc          = "floating"      ! "all", "marine", "floating", "none", "slab"
+    ssa_beta_max        = 1e20            ! [Pa a m-1] Maximum value of beta for which ssa should be calculated
+    ssa_vel_max         = 5000.0          ! [m a-1] SSA velocity limit to avoid spurious results
+    ssa_iter_max        = 5               ! Number of maximum allowed iterations over ssa to converge on vel. solution
+    ssa_iter_rel        = 0.7             ! [--] Relaxation fraction [0:1] to stabilize ssa iterations
+    ssa_iter_conv       = 1e-2            ! [--] L2 relative error convergence limit to exit ssa iterations
+    taud_lim            = 2e5             ! [Pa] Maximum allowed driving stress
+    cb_sia              = 0.0             ! [m a-1 Pa-1] Bed roughness coefficient for SIA sliding
+
+/
+
+&ytill
+    method          = 1                 ! -1: set externally; 1: calculate cb_ref online
+    scale_zb        = 1                 ! 0: none, 1: lin, 2: exp : scaling with elevation
+    scale_sed       = 0                 ! 0: none, 1: min(cb_zb,cb_sed), 2: cb_zb*(lambda_sed*f_sed), 3: 2 but no lower limit
+    is_angle        = False             ! cb_ref is a till strength angle?
+    n_sd            = 10                ! Number of samples over z_bed_sd field
+    f_sed           = 1.0               ! Scaling reduction for thick sediments 
+    sed_min         = 5.0               ! [m] Sediment thickness for no reduction in friction
+    sed_max         = 15.0              ! [m] Sediment thickness for maximum reduction in friction
+    z0              = -300.0            ! [m] Bedrock rel. to sea level, lower limit
+    z1              =  200.0            ! [m] Bedrock rel. to sea level, upper limit
+    cf_min          =  0.01             ! [-- or deg] Minimum value of cf
+    cf_ref          =  1.002		! 0.8              ! [-- or deg] Reference/const/max value of cf
+/
+
+&yneff 
+    method          = 3                 ! -1: external N_eff, 0: neff_const, 1: overburden pressure, 2: Leguy param., 3: Till pressure
+    nxi             = 0                 ! 0: no subgrid interpolation, 1: Guassian quadrature of Neff, > 1: interpolate cell H_w to nxi x nxi points.
+    const           = 1e7               ! == rho_ice*g*(eg 1000 m ice thickness)
+    p               = 0.0               ! *neff_method=2* marine connectivity exponent (0: none, 1: full)
+    H_w_max         = -1.0              ! < 0: Use ytherm.H_w_max; >= 0: Saturation water thickness for neff_method=3.
+    N0              = 1000.0            ! [Pa] *neff_method=3* Reference effective pressure 
+    delta           = 0.04              ! [--] *neff_method=3* Fraction of overburden pressure for saturated till
+    e0              = 0.69              ! [--] *neff_method=3* Reference void ratio at N0 
+    Cc              = 0.12              ! [--] *neff_method=3* Till compressibility    
+    s_const         = 0.5               ! [--] *neff_method=4* Imposed constant till water saturation level    
+/
+
+&ymat
+    flow_law                = "glen"        ! Only "glen" is possible right now
+    rf_method               = 1             ! -1: set externally; 0: rf_const everywhere; 1: standard function 
+    rf_const                = 1e-18         ! [Pa^-3 a^-1]
+    rf_use_eismint2         = False         ! Only applied for rf_method=1
+    rf_with_water           = False         ! Only applied for rf_method=1, scale rf by water content?
+    n_glen                  = 3.0           ! Glen flow law exponent
+    visc_min                = 1e3           ! [Pa a] Minimum allowed viscosity 
+    de_max                  = 0.5           ! [a-1]  Maximum allowed effective strain rate
+    enh_method              = "shear3D"     ! "simple","shear2D", "shear3D", "paleo-shear" 
+    enh_shear               = 3.093         !3.0
+    enh_stream              = 1.0
+    enh_shlf                = 0.7
+    enh_umin                = 50.0          ! [m/yr] Minimum transition velocity to enh_stream (enh_method="paleo-shear")
+    enh_umax                = 500.0         ! [m/yr] Maximum transition velocity to enh_stream (enh_method="paleo-shear")
+    calc_age                = False         ! Calculate age tracer field?
+    age_iso                 = 11.7, 29.0, 57.0, 115.0
+    tracer_method           = "expl"        ! "expl", "impl": used for age and 'paleo-shear' enh fields
+    tracer_impl_kappa       = 1.5           ! [m2 a-1] Artificial diffusion term for implicit tracer solving 
+    
+/
+
+&ytherm
+    method          = "temp"            ! "fixed", "robin", "temp", "enth"
+    qb_method       = 2                 ! 1: simple-stagger, 2: quadrature
+    dt_method       = "FE"              ! "FE", "AB", "SAM"
+    solver_advec    = "impl-upwind"     ! "expl", "impl-upwind"
+    gamma           = 1.0               ! [K] Scalar for the pressure melting point decay function
+    use_strain_sia  = False             ! True: calculate strain heating from SIA approx.
+    use_const_cp    = False             ! Use specified constant value of heat capacity?
+    const_cp        = 2009.0            ! [J kg-1 K-1] Specific heat capacity 
+    use_const_kt    = False             ! Use specified constant value of heat conductivity?
+    const_kt        = 6.62e7            ! [J a-1 m-1 K-1] Thermal conductivity [W m-1 K-1 * sec_year] => [J a-1 m-1 K-1]
+    enth_cr         = 1e-3              ! [--] Conductivity ratio for temperate ice (kappa_temp     = enth_cr*kappa_cold)
+    omega_max       = 0.01              ! [--] Maximum allowed water content fraction 
+    till_rate       = 1e-3              ! [m/a] Basal water till drainage rate (water equiv.)
+    H_w_max         = 2.0               ! [m] Maximum limit to basal water layer thickness (water equiv.)
+
+    rock_method     = "active"          ! "equil" (not active bedrock) or "active"
+    nzr_aa          = 5                 ! Number of vertical points in bedrock 
+    zeta_scale_rock = "exp-inv"         ! "linear", "exp-inv"
+    zeta_exp_rock   = 2.0  
+    H_rock          = 2000.0            ! [m] Lithosphere thickness 
+    cp_rock         = 1000.0            ! [J kg-1 K-1] Specific heat capacity of bedrock
+    kt_rock         = 6.3e7             ! [J a-1 m-1 K-1] Thermal conductivity of bedrock [W m-1 K-1 * sec_year] => [J a-1 m-1 K-1]
+/
+
+&yelmo_masks
+    basins_load     = False 
+    basins_path     = "ice_data/{domain}/{grid_name}/{grid_name}_REGIONS.nc" 
+    basins_nms      = "mask" "regions"
+    regions_load    = True 
+    regions_path    = "ice_data/{domain}/{grid_name}/{grid_name}_REGIONS.nc"
+    regions_nms     = "mask" "None"
+/
+
+&yelmo_init_topo
+    init_topo_load    = True 
+    init_topo_path    = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO.nc"
+    init_topo_names   = "H_ice" "z_bed" "z_bed_err" "z_srf"      ! Ice thickness, bedrock elevation, bedrock noise, surface elevation
+    init_topo_state   = 0                                       ! 0: from file, 1: ice-free, 2: ice-free, rebounded 
+    z_bed_f_sd        = 0.0                                     ! Scaling fraction to modify z_bed = z_bed + f_sd*z_bed_sd
+    smooth_H_ice      = 0.0                                     ! Smooth ice thickness field at loading time, with sigma=N*dx
+    smooth_z_bed      = 0.0                                     ! Smooth bedrock field at loading time, with sigma=N*dx
+    
+/
+
+
+&yelmo_data 
+    pd_topo_load      = True 
+    pd_topo_path      = "ice_data/{domain}/{grid_name}/{grid_name}_TOPO.nc"
+    pd_topo_names     = "H_ice" "z_bed" "z_bed_err" "z_srf"  ! Ice thickness, bedrock elevation, bedrock noise, surface elevation
+    pd_tsrf_load      = True 
+    pd_tsrf_path      = "ice_data/{domain}/{grid_name}/{grid_name}_LIA-1851-1871_NOAA_V2c.nc"
+    pd_tsrf_name      = "t2m"                      ! Surface temperature (or near-surface temperature)
+    pd_tsrf_monthly   = True
+    pd_smb_load       = False 
+    pd_smb_path       = "none"
+    pd_smb_name       = "smb"                        ! Surface mass balance 
+    pd_smb_monthly    = False 
+    pd_vel_load       = False 
+    pd_vel_path       = "none"
+    pd_vel_names      = "ux_srf" "uy_srf"            ! Surface velocity 
+    pd_age_load       = False 
+    pd_age_path       = "none"
+    pd_age_names      = "age_iso" "depth_iso"        ! ages of isochrones; depth of isochrones 
+
+/
+
+
+! ===== EXTERNAL LIBRARIES =====
+
+&snap
+    atm_type           = "const"
+    ocn_type           = "const"
+    fname_at           = "input/alpha_orbital_r2020.dat"
+    fname_ao           = "input/alpha_orbital_r2020.dat"
+    fname_ap           = "input/alpha_orbital_r2020.dat"
+    fname_as           = "input/salinity_index_deglaciation.dat"
+    fname_bt           = "input/ones.dat"
+    fname_bo           = "input/ones.dat"
+    fname_bp           = "input/ones.dat"
+    fname_bs           = "input/ones.dat"
+    lapse              = 0.0080 0.0065    ! lapse_ann, lapse_sum 
+    dTa_const          = 2.0  
+    dTo_const          = 0.5
+    dSo_const          = 3.0
+    f_to               = 0.25 
+    f_p                = 0.096
+    f_stdev            = 0.0 
+/
+
+!&snap_hybrid
+!    hybrid_path        = "ice_data/Greenland/paleo300ka_hybrid_aicc2012.nc"
+!    f_eem              = 0.3 
+!    f_glac             = 1.0 
+!    f_hol              = 0.5 
+!    f_seas             = 1.0 
+!    f_to               = 0.2
+!/
+
+!&snap_recon
+!    clim_path       = "ice_data/{domain}/{grid_name}/{grid_name}_CLIM-RECON-B20.nc"
+!    clim_names      = "time" "tas" "pr" "zs"
+!    clim_monthly    = False
+!    ocn_path        = "ice_data/{domain}/{grid_name}/{grid_name}_OCN-RECON-TRACE21ka.nc"
+!    ocn_names       = "time" "depth" "mask_ocn" "to"
+!    ocn_monthly     = False
+!/
+
+&snap_clim0
+    clim_path       = "ice_data/{domain}/{grid_name}/{grid_name}_LIA-1851-1871_NOAA_V2c.nc"
+    clim_names      = "z_srf" "t2m" "pr" ""                                                   ! Default (if monthly = True) : "zs" "t3m" "sf" "rf"
+    clim_monthly    = True                                                                   ! If True and no snowfall (sf) then the third variable is precip and the fourth one irrelevant
+    clim_time       = 0
+    clim_stdev_path = "None"
+    clim_stdev_name = "pr" 
+    ocn_path        = "ice_data/{domain}/{grid_name}/{grid_name}_OCEAN_ZERO.nc"
+    ocn_names       = "depth" "mask_ocn" "to" "so"
+    ocn_monthly     = True
+    ocn_time        = 0
+/
+
+!
+! DELETDE snap_clim1-3
+!
+&smbpal
+    const_insol = True
+    const_kabp  = 0.0
+    insol_fldr  = "input"
+    abl_method  = "itm"   ! "itm" or "pdd"
+    sigma_snow  = 8.27 !5.0     ! Standard deviation of temperature [K] over ice and snow
+    sigma_melt  = 8.27 !5.0     ! Standard deviation of temperature [K] in ablation zone
+    sigma_land  = 8.27 !5.0     ! Standard deviation of temperature [K] over land 
+    
+    sf_a        = 0.273   ! Snow fraction function (parameter a)
+    sf_b        = 273.6   ! Snow fraction function (parameter b)
+    firn_fac    = 0.0266  ! Reduction in surface temp versus melting [K/mm w.e.]
+
+    mm_snow = 4.424 !3.0         ! PDD snow melt factor [mm w.e./K-d]
+    mm_ice  = 7.0 !8.0         ! PDD ice melt factor  [mm w.e./K-d]
+    
+/
+
+&itm
+        
+    H_snow_max      =  5.0e3         ! Maximum allowed snowpack thickness [mm w.e.]
+    Pmaxfrac        =  0.6           ! Refreezing factor 
+    
+    ! ## ITM 
+    trans_a         =  0.46 
+    trans_b         =  6e-5
+    trans_c         =  0.01
+    itm_c           = -45.0
+    itm_t           =  10.0
+    itm_b           =  -2.0 
+    itm_lat0        =  65.0 
+
+    ! ## Surface albedo
+    alb_snow_dry       =  0.8
+    alb_snow_wet       =  0.65
+    alb_ice            =  0.4
+    alb_land           =  0.2
+    alb_forest         =  0.1
+    alb_ocean          =  0.1
+    H_snow_crit_desert =  10.0
+    H_snow_crit_forest = 100.0
+    melt_crit          =   0.5      ! Critical melt rate to reduce snow albedo [mm/day]
+
+/
+
+&marine_shelf
+    bmb_method      = "anom"        ! "pico", "anom", "lin", "quad", "quad-nl", "*-slope"
+    tf_method       = 2             ! 0: tf defined externally, 1: calculate as T_shlf-t_fp_shlf, 2: use dT_shlf
+    interp_depth    = "shlf"        ! "shlf", "bed", "const"
+    interp_method   = "interp"      ! "mean", "layer", "interp" ! Same method is used for salinity
+    find_ocean      = True          ! Find which points are connected to open ocean (ie, ignore subglacial lakes)
+    
+    corr_method     = "tf-grl"      ! "tf": corrected tf basin, "bmb": corrected bmb basin, "tf-grl": use values in tf_corr_grl parameter section
+    basin_number    = 1             ! 1 2 3
+    basin_bmb_corr  = 0.0           ! -1.0  -1.0 -1.0 [corrected bmb m/yr; -: melting, +: accretion]
+    basin_tf_corr   = 0.5           ! 1.0   2.0  3.0  
+    tf_correction   = False
+    tf_path         = "ice_data_javi/{domain}/{grid_name}/Ocean_parameterization_J20.nc"
+    tf_name         = "dT_nl"
+ 
+    bmb_max         = 0.0           ! [m/a] Maximum allowed bmb value (eg, for no refreezing, set bmb_max=0.0) 
+    
+    ! Deep ocean bmb 
+    c_deep          = -10.0         ! [m/yr] Melt rate in deep ocean, should be negative but not huge
+    depth_deep      =  500.0        ! [m] Depth at which deep ocean is assumed
+    depth_const     =    0.0        ! [m] Constant shelf depth for interp_depthconst
+    depth_min       = 1100.0        ! [m] interp_method=mean, min depth to include
+    depth_max       = 1500.0        ! [m] interp_method=mean, max depth to include
+    
+    ! Freezing point coefficients
+    lambda1         = -0.0575       ! [degC PSU−1] Liquidus slope
+    lambda2         = 0.0832        ! [degC] Liquidus intercept 
+    lambda3         = 7.59e-4       ! [degC m−1] Liquidus pressure coefficient
+
+    ! bmb_method == [lin,quad,quad-nl] 
+    gamma_lin       = 630.0         ! [m/yr] Linear heat excange velocity. Favier et al., (2019) suggest 630.
+    gamma_quad      = 11100.0       ! [m/yr] Quadratic heat exchange velocity. Jourdain et al. (2020) suggest 11100.
+    gamma_quad_nl   = 14500.0       ! [m/yr] Quadratic non-local heat exchange velocity. Jourdain et al. (2020) suggest 14500.
+    gamma_prime     = 100.0         ! [-] Scalar when '*-slope' method is used
+
+    ! bmb_method == anom
+    kappa_grz       = 10.0          ! [m/yr K-1] Heat flux coefficient [kappa*dT]
+    c_grz           = 1.0           ! [-] bmb_ref scalar [c_grz*bmb_ref]
+    f_grz_shlf      = 10.0          ! [-] Ratio of grz melt to shelf melt
+    grz_length      = 32.0          ! [km] Length scale of assumed grounding zone
+
+    ! bmb_method == anom, bmb_ref parameters 
+    use_obs         = False         ! Load obs for bmb_ref
+    obs_path        = "ice_data/{domain}/{grid_name}/{grid_name}_BMELT-R13.nc"
+    obs_name        = "bm_eq_reese"
+    obs_scale       = 1.0           ! [-] bmb_ref = obs_scale*bmb_obs
+    obs_lim         = 100.0         ! [m/yr] Maximum magnitude of bmb_ref
+    basin_name      = "none"        !"northwest" "northeast" "east"
+    basin_bmb       = 0.0           !        -1.0       -1.0   -1.0
+    
+/
+
+&tf_corr_grl
+    ne      = 0.0                   ! [K] tf_corr for northeast/negis basin (basin=2)
+    e       = 1.0                   ! [K] tf_corr for eastern basin (basin=3)
+    se      = 1.5                   ! [K] tf_corr for southeast basin (basin=4)
+    w       = 0.0                   ! [K] tf_corr for western basin (basins=[6,7,8])
+/
+
+
+&sed
+    use_obs   = True
+    obs_path  = "ice_data/{domain}/{grid_name}/{grid_name}_SED-L97.nc"
+    obs_name  = "z_sed"
+
+/
+
+&ghf
+    use_obs   = False
+    obs_path  = "ice_data/{domain}/{grid_name}/{grid_name}_GHF-M05.nc"
+    obs_name  = "ghf"
+    ghf_const = 50.0           ! [mW/m^2]
+
+/
+
+&isos
+    ! Options
+    heterogeneous_ssh    = .false.   ! Sea level varies spatially?
+    interactive_sealevel = .false.   ! Sea level interacts with solid Earth deformation?
+    include_elastic      = .false.   ! Include elastic deformation?
+    correct_compression  = .false.   ! Account for compression effects on relaxation time?
+    correct_distortion   = .false.   ! Account for distortion of projection?
+    method               = 2         ! 0: constant displacement; 1: LLRA; 2: LV-ELRA, 3: LV-ELVA
+    dt_prognostics       = 1.0       ! [yr] Max. timestep to recalculate prognostics  (was dt_step)
+    dt_diagnostics       = 1.0       ! [yr] Min. timestep to recalculate diagnostics  (was dt_lith)
+    pad                  = 512.      ! [km] Padding around domain (power of 2 * resolution).
+                                     ! Needed when method = 3 (LV-ELVA) is enabled.
+
+    ! Rheology methods
+    mantle      = "uniform"          ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    lithosphere = "uniform"          ! "uniform", "gaussian_plus", "gaussian_minus", "rheology_file"
+    layering    = "equalized"        ! "parallel" or "equalized"
+    lumping     = "freqdomain"       ! "bottom", "min", "max", "mean", "logmean", "freqdomain"
+    viscosity_scaling_method = "scale" ! "scale" or "min" or "max"
+    viscosity_scaling = 1.
+
+    ! Rheology parameters
+    nl            = 2                ! [1] Number of viscous layers for sub-lithospheric mantle
+    zl            = 100.0, 150.0     ! [km] zl(1) sets uniform lithospheric thickness (= old He_lith)
+    viscosities   = 1.0e21, 1.0e21   ! [Pa s] Layer viscosities (uniform mantle).
+    ref_viscosity = 1.e21            ! [Pa s] Reference viscosity for scaling
+    tau           = 3000.0           ! [yr] Relaxation time used for method = 2 (ELRA)
+
+    ! Physical constants
+    E               = 66.0           ! [GPa] Young modulus
+    nu              = 0.28           ! [-] Poisson ratio
+    rho_ice         = 910.           ! [kg/m^3]
+    rho_seawater    = 1028.0         ! [kg/m^3]
+    rho_water       = 1000.0         ! [kg/m^3]
+    rho_uppermantle = 3400.0         ! [kg/m^3]
+    rho_litho       = 0.0            ! [kg/m^3]  0 ==> decouple elastic from viscous displacement
+    g               = 9.81           ! [m/s^2]
+    r_earth         = 6.378e3        ! [km] Earth radius
+    m_earth         = 5.972e24       ! [kg] Earth mass
+
+    ! Files
+    restart       = "None"
+    mask_file     = "None"
+    rheology_file = "None"
+/
+
+&barysealevel
+    method       = "const"   ! "const": BSL = bsl_init throughout sim
+                             ! "file": BSL = time series provided from sl_path
+                             ! "fastiso": BSL = sum of contributions from fastiso domains
+    bsl_init     = 0.0       ! [m] BSL relative to present day
+    sl_path      = "none"    ! Input time series filename
+    sl_name      = "none"    ! Variable name in netcdf file, if relevant
+    A_ocean_pd   = 3.625e14  ! [m^2] Ocean surface as in Goelzer et al. (2020)
+    A_ocean_path = "None"    ! Path to ocean surface file
+    restart      = "None"    ! Path to restart file
+/

--- a/par/yelmo_bipolar.nml
+++ b/par/yelmo_bipolar.nml
@@ -163,7 +163,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_ismip6_Antarctica.nml
+++ b/par/yelmo_ismip6_Antarctica.nml
@@ -179,7 +179,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_nahosmip_Antarctica.nml
+++ b/par/yelmo_nahosmip_Antarctica.nml
@@ -179,7 +179,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_pd_Antarctica.nml
+++ b/par/yelmo_pd_Antarctica.nml
@@ -146,7 +146,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     

--- a/par/yelmo_pd_Greenland.nml
+++ b/par/yelmo_pd_Greenland.nml
@@ -179,7 +179,9 @@
 &ycalv
     ! === calving method & law ===
     use_lsf             = True              ! use level-set method
+    lsf_method          = "snap"            ! "snap" (legacy neighbour-snap) or "redist" (Sussman/Osher)
     dt_lsf              = -1                ! [yr] lsf update timescale. If negative: no reset.
+    lsf_redist_n_iter   = 5                 ! Sussman/Osher LSF redistancing iterations. redist mode only.
     calv_flt_method     = "vm-m16"          ! "zero", "simple", "flux", "vm-l19", "kill"
     calv_grnd_method    = "zero"            ! "zero", "stress-b12"
     


### PR DESCRIPTION
## Summary
- Add `lsf_method = "snap"` and `lsf_redist_n_iter = 5` to `&ycalv` in all 16 yelmox par files (Antarctica/Greenland/LIS/North/Pyrenees/bipolar/ismip6/nahosmip/pd_*/PMYY_MAG_Bipolar/*), bringing every file in line with the yelmo2/par/yelmo_initmip.nml schema. Both keys are read by yelmo at init time via `&ycalv` ([yelmo_topography.f90](https://github.com/palma-ice/yelmo/blob/main/src/yelmo_topography.f90)) and are inert when `use_lsf = False` or `lsf_method = "snap"`.
- Add a new SPI-1KM par file ported from `patagonia-dev`. Translates the old standalone-isostasy block to the FastIsostasy schema (ELRA via `method = 2` LV-ELRA with `mantle = "uniform"`/`lithosphere = "uniform"`, `tau = 3000`, `He_lith = 100` km via `zl(1) = 100`; `pad = 512` km for future LV-ELVA). Adds `&barysealevel` group. Brings all yelmo groups into line with the current schema: new `&ycalv` (split from `&ytopo`), `nml_ycalv` pointer in `&yelmo`, `ydyn.{uz_method, scale_T, T_frz, ssa_solver}` and split `ssa_lis_opt`, `ytill.{scale_zb = 1, scale_sed = 0}`, `ytherm.qb_method`. Renames `&sediments` → `&sed` and `&geothermal` → `&ghf`. Drops obsolete `&sealevel` and `&ice_enh` groups.

## Test plan
- [ ] Build a yelmox program (e.g. `make yelmox` or `make yelmox_glaciers`) and confirm no namelist read errors on a representative par file (Antarctica + Greenland + Pyrenees).
- [ ] Run a short test simulation with `yelmox` using one of the updated par files and confirm calving behavior is unchanged when `use_lsf = False` / `lsf_method = "snap"`.
- [ ] If SPI is targeted: run a short equilibration with `yelmo_SPI_lia_new.nml` to confirm the par file parses cleanly and the FastIsostasy ELRA mapping produces reasonable bedrock response (`ts%dz_bed`).